### PR TITLE
Tailwind v4 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@serwist/build": "^9.0.14",
     "@serwist/next": "^9.0.14",
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/better-sqlite3": "^7.6.9",
     "@types/countries-and-timezones": "^3.2.6",
     "@types/ioredis": "^5.0.0",
@@ -137,7 +138,6 @@
     "@types/react-grid-layout": "^1.3.5",
     "@types/swagger-ui-react": "^5.18.0",
     "@types/ws": "^8.18.1",
-    "autoprefixer": "^10.4.17",
     "dotenv": "^16.5.0",
     "dotenv-cli": "^8.0.0",
     "drizzle-kit": "^0.31.0",
@@ -149,7 +149,7 @@
     "postcss": "^8.4.35",
     "prettier": "^3.2.5",
     "serwist": "^9.0.14",
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 1.2.4(@types/react-dom@18.3.7(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@scalar/api-reference-react':
         specifier: ^0.7.7
-        version: 0.7.7(axios@1.9.0)(react@18.3.1)(tailwindcss@3.4.17)(typescript@5.8.3)
+        version: 0.7.7(axios@1.9.0)(react@18.3.1)(tailwindcss@4.1.11)(typescript@5.8.3)
       '@scalar/nextjs-api-reference':
         specifier: ^0.8.3
         version: 0.8.3(next@15.3.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -292,7 +292,7 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17)
+        version: 1.0.7(tailwindcss@4.1.11)
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@18.3.1)
@@ -327,6 +327,9 @@ importers:
       '@serwist/next':
         specifier: ^9.0.14
         version: 9.0.14(next@15.3.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
+      '@tailwindcss/postcss':
+        specifier: ^4.1.11
+        version: 4.1.11
       '@types/better-sqlite3':
         specifier: ^7.6.9
         version: 7.6.13
@@ -357,9 +360,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      autoprefixer:
-        specifier: ^10.4.17
-        version: 10.4.21(postcss@8.5.3)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -394,8 +394,8 @@ importers:
         specifier: ^9.0.14
         version: 9.0.14(typescript@5.8.3)
       tailwindcss:
-        specifier: ^3.4.1
-        version: 3.4.17
+        specifier: ^4.1.11
+        version: 4.1.11
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1272,6 +1272,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -2355,6 +2359,94 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@tailwindcss/node@4.1.11':
+    resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.11':
+    resolution: {integrity: sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.11':
+    resolution: {integrity: sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.11':
+    resolution: {integrity: sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.11':
+    resolution: {integrity: sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.11':
+    resolution: {integrity: sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.11':
+    resolution: {integrity: sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
+    resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
+    resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.11':
+    resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.11':
+    resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.11':
+    resolution: {integrity: sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.11':
+    resolution: {integrity: sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.11':
+    resolution: {integrity: sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.11':
+    resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
   '@tanstack/query-core@5.76.0':
     resolution: {integrity: sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==}
 
@@ -2844,16 +2936,6 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2918,13 +3000,6 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  autoprefixer@10.4.21:
-    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2961,10 +3036,6 @@ packages:
   better-sqlite3@9.6.0:
     resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -2983,11 +3054,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.24.5:
-    resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.25.1:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
@@ -3034,10 +3100,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
 
   caniuse-lite@1.0.30001716:
     resolution: {integrity: sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==}
@@ -3088,10 +3150,6 @@ packages:
   chevrotain@10.5.0:
     resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
-
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -3102,6 +3160,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -3178,10 +3240,6 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
   commist@3.2.0:
     resolution: {integrity: sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==}
 
@@ -3233,11 +3291,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -3423,14 +3476,8 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3640,9 +3687,6 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.149:
-    resolution: {integrity: sha512-UyiO82eb9dVOx8YO3ajDf9jz2kKyt98DEITRdeLPstOEuTlLzDA4Gyq5K9he71TQziU5jUVu2OAu5N48HmQiyQ==}
-
   electron-to-chromium@1.5.192:
     resolution: {integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==}
 
@@ -3660,6 +3704,10 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  enhanced-resolve@5.18.3:
+    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
+    engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -4002,9 +4050,6 @@ packages:
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
-
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   framer-motion@11.18.2:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
@@ -4369,10 +4414,6 @@ packages:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -4516,10 +4557,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
-
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -4645,23 +4682,79 @@ packages:
 
   libsql@0.5.8:
     resolution: {integrity: sha512-+OopMI1wM/NvAJTHf3O3+beHd1YfKLnSVsOGBl3/7UBDZ4ydVadkbBk5Hjjs9d3ALC5rBaftMY59AvwyC8MzPw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   license-checker@25.0.1:
     resolution: {integrity: sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==}
     hasBin: true
 
+  lightningcss-darwin-arm64@1.30.1:
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.1:
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.1:
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.1:
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.1:
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
-
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4911,6 +5004,10 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -4920,6 +5017,11 @@ packages:
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4945,9 +5047,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5051,14 +5150,6 @@ packages:
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
-    engines: {node: '>=0.10.0'}
-
   npm-normalize-package-bin@1.0.1:
     resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
 
@@ -5073,10 +5164,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -5225,14 +5312,6 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -5243,43 +5322,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.0.1:
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -5535,9 +5577,6 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
   read-installed@4.0.3:
     resolution: {integrity: sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==}
     deprecated: This package is no longer supported.
@@ -5557,10 +5596,6 @@ packages:
   readdir-scoped-modules@1.1.0:
     resolution: {integrity: sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==}
     deprecated: This functionality has been moved to @npmcli/fs
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5972,11 +6007,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -6005,10 +6035,12 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
+  tailwindcss@4.1.11:
+    resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
+
+  tapable@2.2.2:
+    resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
+    engines: {node: '>=6'}
 
   tar-fs@2.1.2:
     resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
@@ -6021,12 +6053,9 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -6074,9 +6103,6 @@ packages:
   ts-deepmerge@7.0.3:
     resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
     engines: {node: '>=14.13.1'}
-
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -6398,6 +6424,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
@@ -7227,9 +7257,9 @@ snapshots:
     dependencies:
       graphql: 15.10.1
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17)':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.1.11)':
     dependencies:
-      tailwindcss: 3.4.17
+      tailwindcss: 4.1.11
 
   '@headlessui/vue@1.7.23(vue@3.5.16(typescript@5.8.3))':
     dependencies:
@@ -7375,6 +7405,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -8306,9 +8340,9 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@scalar/api-client@2.5.1(axios@1.9.0)(tailwindcss@3.4.17)(typescript@5.8.3)':
+  '@scalar/api-client@2.5.1(axios@1.9.0)(tailwindcss@4.1.11)(typescript@5.8.3)':
     dependencies:
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.1.11)
       '@headlessui/vue': 1.7.23(vue@3.5.16(typescript@5.8.3))
       '@scalar/components': 0.14.4(typescript@5.8.3)
       '@scalar/draggable': 0.2.0(typescript@5.8.3)
@@ -8357,9 +8391,9 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@scalar/api-reference-react@0.7.7(axios@1.9.0)(react@18.3.1)(tailwindcss@3.4.17)(typescript@5.8.3)':
+  '@scalar/api-reference-react@0.7.7(axios@1.9.0)(react@18.3.1)(tailwindcss@4.1.11)(typescript@5.8.3)':
     dependencies:
-      '@scalar/api-reference': 1.31.2(axios@1.9.0)(tailwindcss@3.4.17)(typescript@5.8.3)
+      '@scalar/api-reference': 1.31.2(axios@1.9.0)(tailwindcss@4.1.11)(typescript@5.8.3)
       '@scalar/types': 0.2.1
       react: 18.3.1
     transitivePeerDependencies:
@@ -8378,11 +8412,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@scalar/api-reference@1.31.2(axios@1.9.0)(tailwindcss@3.4.17)(typescript@5.8.3)':
+  '@scalar/api-reference@1.31.2(axios@1.9.0)(tailwindcss@4.1.11)(typescript@5.8.3)':
     dependencies:
       '@floating-ui/vue': 1.1.6(vue@3.5.16(typescript@5.8.3))
       '@headlessui/vue': 1.7.23(vue@3.5.16(typescript@5.8.3))
-      '@scalar/api-client': 2.5.1(axios@1.9.0)(tailwindcss@3.4.17)(typescript@5.8.3)
+      '@scalar/api-client': 2.5.1(axios@1.9.0)(tailwindcss@4.1.11)(typescript@5.8.3)
       '@scalar/code-highlight': 0.1.1
       '@scalar/components': 0.14.4(typescript@5.8.3)
       '@scalar/icons': 0.4.2(typescript@5.8.3)
@@ -8693,6 +8727,78 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tailwindcss/node@4.1.11':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      enhanced-resolve: 5.18.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      magic-string: 0.30.17
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.11
+
+  '@tailwindcss/oxide-android-arm64@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.11':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.11':
+    dependencies:
+      detect-libc: 2.0.4
+      tar: 7.4.3
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.11
+      '@tailwindcss/oxide-darwin-arm64': 4.1.11
+      '@tailwindcss/oxide-darwin-x64': 4.1.11
+      '@tailwindcss/oxide-freebsd-x64': 4.1.11
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.11
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.11
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.11
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.11
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.11
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.11
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
+
+  '@tailwindcss/postcss@4.1.11':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.11
+      '@tailwindcss/oxide': 4.1.11
+      postcss: 8.5.3
+      tailwindcss: 4.1.11
 
   '@tanstack/query-core@5.76.0': {}
 
@@ -9190,15 +9296,6 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  any-promise@1.3.0: {}
-
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
-  arg@5.0.2: {}
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.4:
@@ -9289,16 +9386,6 @@ snapshots:
   asynckit@0.4.0:
     optional: true
 
-  autoprefixer@10.4.21(postcss@8.5.3):
-    dependencies:
-      browserslist: 4.24.5
-      caniuse-lite: 1.0.30001716
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -9354,8 +9441,6 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
-  binary-extensions@2.3.0: {}
-
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -9385,13 +9470,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.24.5:
-    dependencies:
-      caniuse-lite: 1.0.30001716
-      electron-to-chromium: 1.5.149
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.24.5)
 
   browserslist@4.25.1:
     dependencies:
@@ -9454,8 +9532,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   caniuse-lite@1.0.30001716: {}
 
   caniuse-lite@1.0.30001731: {}
@@ -9503,18 +9579,6 @@ snapshots:
       lodash: 4.17.21
       regexp-to-ast: 0.5.0
 
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -9522,6 +9586,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   citty@0.1.6:
     dependencies:
@@ -9602,8 +9668,6 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@4.1.1: {}
-
   commist@3.2.0: {}
 
   common-tags@1.8.2: {}
@@ -9642,8 +9706,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
 
@@ -9794,11 +9856,7 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
-  didyoumean@1.2.2: {}
-
   diff-match-patch@1.0.5: {}
-
-  dlv@1.1.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -9859,8 +9917,6 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.149: {}
-
   electron-to-chromium@1.5.192: {}
 
   emoji-regex-xs@1.0.0: {}
@@ -9876,6 +9932,11 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.18.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.2
 
   entities@4.5.0: {}
 
@@ -10399,8 +10460,6 @@ snapshots:
 
   frac@1.1.2: {}
 
-  fraction.js@4.3.7: {}
-
   framer-motion@11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       motion-dom: 11.18.1
@@ -10856,10 +10915,6 @@ snapshots:
     dependencies:
       has-bigints: 1.1.0
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-boolean-object@1.2.2:
     dependencies:
       call-bound: 1.0.4
@@ -11004,8 +11059,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jiti@1.21.7: {}
-
   jiti@2.4.2: {}
 
   jose@5.10.0: {}
@@ -11135,11 +11188,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss@1.30.1:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.1
+      lightningcss-darwin-x64: 1.30.1
+      lightningcss-freebsd-x64: 1.30.1
+      lightningcss-linux-arm-gnueabihf: 1.30.1
+      lightningcss-linux-arm64-gnu: 1.30.1
+      lightningcss-linux-arm64-musl: 1.30.1
+      lightningcss-linux-x64-gnu: 1.30.1
+      lightningcss-linux-x64-musl: 1.30.1
+      lightningcss-win32-arm64-msvc: 1.30.1
+      lightningcss-win32-x64-msvc: 1.30.1
+
   lilconfig@2.1.0: {}
-
-  lilconfig@3.1.3: {}
-
-  lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -11192,7 +11286,7 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   markdown-table@3.0.4: {}
 
@@ -11588,6 +11682,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -11595,6 +11693,8 @@ snapshots:
       minimist: 1.2.8
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   mlly@1.7.4:
     dependencies:
@@ -11641,12 +11741,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -11733,10 +11827,6 @@ snapshots:
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
 
-  normalize-path@3.0.0: {}
-
-  normalize-range@0.1.2: {}
-
   npm-normalize-package-bin@1.0.1: {}
 
   number-allocator@1.0.14:
@@ -11756,8 +11846,6 @@ snapshots:
       ufo: 1.6.1
 
   object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -11918,10 +12006,6 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  pify@2.3.0: {}
-
-  pirates@4.0.7: {}
-
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -11931,37 +12015,6 @@ snapshots:
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss-import@15.1.0(postcss@8.5.3):
-    dependencies:
-      postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-js@4.0.1(postcss@8.5.3):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.3
-
-  postcss-load-config@4.0.2(postcss@8.5.3):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.7.1
-    optionalDependencies:
-      postcss: 8.5.3
-
-  postcss-nested@6.2.0(postcss@8.5.3):
-    dependencies:
-      postcss: 8.5.3
-      postcss-selector-parser: 6.1.2
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -12264,10 +12317,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
-
   read-installed@4.0.3:
     dependencies:
       debuglog: 1.0.1
@@ -12306,10 +12355,6 @@ snapshots:
       dezalgo: 1.0.4
       graceful-fs: 4.2.11
       once: 1.4.0
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
 
   readdirp@4.1.2: {}
 
@@ -12838,16 +12883,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.27.1
 
-  sucrase@3.35.0:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      commander: 4.1.1
-      glob: 10.4.5
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      ts-interface-checker: 0.1.13
-
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -12868,36 +12903,13 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
+  tailwindcss-animate@1.0.7(tailwindcss@4.1.11):
     dependencies:
-      tailwindcss: 3.4.17
+      tailwindcss: 4.1.11
 
-  tailwindcss@3.4.17:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.3
-      postcss-import: 15.1.0(postcss@8.5.3)
-      postcss-js: 4.0.1(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)
-      postcss-nested: 6.2.0(postcss@8.5.3)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
+  tailwindcss@4.1.11: {}
+
+  tapable@2.2.2: {}
 
   tar-fs@2.1.2:
     dependencies:
@@ -12923,13 +12935,14 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  thenify-all@1.6.0:
+  tar@7.4.3:
     dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
 
   throttleit@2.1.0: {}
 
@@ -12967,8 +12980,6 @@ snapshots:
       typescript: 5.8.3
 
   ts-deepmerge@7.0.3: {}
-
-  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -13117,12 +13128,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.7.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.7.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.7.2
-
-  update-browserslist-db@1.1.3(browserslist@4.24.5):
-    dependencies:
-      browserslist: 4.24.5
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
@@ -13374,6 +13379,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.7.1: {}
 

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,5 @@
 export default {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    "@tailwindcss/postcss": {},
   },
 };

--- a/src/app/(features)/alarm-zones/page.tsx
+++ b/src/app/(features)/alarm-zones/page.tsx
@@ -336,7 +336,7 @@ export default function AlarmZonesPage() {
                       <Skeleton className="h-5 w-28 rounded" /> {/* Zone name */}
                       <Skeleton className="h-5 w-16 rounded-full" /> {/* Device count badge */}
                     </div>
-                    <div className="flex items-center gap-1 flex-shrink-0">
+                    <div className="flex items-center gap-1 shrink-0">
                       <Skeleton className="h-7 w-20 rounded-md" /> {/* Armed state dropdown */}
                       <Skeleton className="h-7 w-7 rounded-md" /> {/* Actions dropdown */}
                     </div>
@@ -423,7 +423,7 @@ export default function AlarmZonesPage() {
   // Define page actions
   const pageActions = (
     <>
-      <div className="relative flex-shrink-0">
+      <div className="relative shrink-0">
         <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
         <Input
           type="search"
@@ -479,7 +479,7 @@ export default function AlarmZonesPage() {
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <div className="flex flex-col h-full"> 
-      <div className="p-4 border-b flex-shrink-0">
+      <div className="p-4 border-b shrink-0">
         <PageHeader 
           title="Alarm Zones"
           description="Manage security zones for coordinated alarm management"
@@ -526,7 +526,7 @@ export default function AlarmZonesPage() {
                   <Card key={location.id} className="overflow-visible">
                     <CardHeader className="flex flex-row items-center justify-between pb-3 bg-muted/25">
                       <div className="flex items-center gap-2 min-w-0">
-                        <Building className="h-5 w-5 flex-shrink-0" />
+                        <Building className="h-5 w-5 shrink-0" />
                         <CardTitle className="truncate" title={location.name}>{location.name}</CardTitle>
                       </div>
                       <Button 

--- a/src/app/(features)/automations/page.tsx
+++ b/src/app/(features)/automations/page.tsx
@@ -70,10 +70,10 @@ export default function AutomationsPage() {
   return (
     <div className="flex-1 space-y-4 p-4 md:p-6">
       {/* Custom header for automations page */}
-      <div className="flex flex-col mb-6 gap-4 flex-shrink-0">
+      <div className="flex flex-col mb-6 gap-4 shrink-0">
         {/* Title and Icon Section */}
-        <div className="flex items-center gap-3 flex-shrink-0">
-          <div className="text-muted-foreground flex-shrink-0">
+        <div className="flex items-center gap-3 shrink-0">
+          <div className="text-muted-foreground shrink-0">
             <Workflow className="h-6 w-6" />
           </div>
           <div>

--- a/src/app/(features)/devices/page.tsx
+++ b/src/app/(features)/devices/page.tsx
@@ -519,7 +519,7 @@ export default function DevicesPage() {
                       <div className="max-w-32 whitespace-nowrap overflow-hidden text-ellipsis cursor-default">
                           {state ? (
                             <Badge variant="outline" className="inline-flex items-center gap-1 px-2 py-0.5 font-normal">
-                              {React.createElement(StateIcon, { className: "h-3 w-3 flex-shrink-0" })}
+                              {React.createElement(StateIcon, { className: "h-3 w-3 shrink-0" })}
                               <span className="text-xs">{state}</span>
                             </Badge>
                           ) : (
@@ -715,7 +715,7 @@ export default function DevicesPage() {
           actions={pageActions}
         />
 
-        <div className="flex-shrink-0">
+        <div className="shrink-0">
           {error && (
             <div className="mb-4 p-3 bg-destructive/10 text-destructive text-sm rounded-md">
               <p>Error: {error}</p>
@@ -737,8 +737,8 @@ export default function DevicesPage() {
 
             {/* Show table only AFTER load and if there is data */} 
             {tableData.length > 0 && (
-              <div className="border rounded-md flex-grow overflow-hidden flex flex-col">
-                <div className="flex-grow overflow-auto"> 
+              <div className="border rounded-md grow overflow-hidden flex flex-col">
+                <div className="grow overflow-auto"> 
                   <Table>
                     <TableHeader className="sticky top-0 bg-background z-10">
                       {table.getHeaderGroups().map((headerGroup) => (
@@ -804,7 +804,7 @@ export default function DevicesPage() {
                     </TableBody>
                   </Table>
                 </div>
-                <div className="flex items-center justify-between p-2 border-t flex-shrink-0">
+                <div className="flex items-center justify-between p-2 border-t shrink-0">
                   <div className="flex-1 text-sm text-muted-foreground">
                     Total Rows: {table.getFilteredRowModel().rows.length}
                   </div>

--- a/src/app/(features)/events/page.tsx
+++ b/src/app/(features)/events/page.tsx
@@ -779,7 +779,7 @@ export default function EventsPage() {
               <TooltipTrigger asChild>
                 <div className="max-w-32 whitespace-nowrap overflow-hidden text-ellipsis cursor-default">
                   <Badge variant="outline" className="inline-flex items-center gap-1 px-2 py-0.5">
-                    {React.createElement(StateIcon, { className: "h-3 w-3 flex-shrink-0" })}
+                    {React.createElement(StateIcon, { className: "h-3 w-3 shrink-0" })}
                     <span>{displayState}</span>
                   </Badge>
                 </div>
@@ -867,7 +867,7 @@ export default function EventsPage() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <DialogTrigger asChild>
-                      <Button variant="outline" size="icon" className="h-6 w-6 flex-shrink-0">
+                      <Button variant="outline" size="icon" className="h-6 w-6 shrink-0">
                         <Play className="h-4 w-4" />
                       </Button>
                     </DialogTrigger>
@@ -1068,7 +1068,7 @@ export default function EventsPage() {
         {videoPlayerProps && isVideoPlayerOpen && (
           <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
             <div className="bg-background rounded-lg shadow-xl max-w-[80vw] max-h-[90vh] w-full mx-4 flex flex-col">
-              <div className="p-4 pb-2 flex flex-row items-center justify-between space-y-0 flex-shrink-0 border-b">
+              <div className="p-4 pb-2 flex flex-row items-center justify-between space-y-0 shrink-0 border-b">
                 <div className="flex items-center gap-2">
                   <Video className="h-5 w-5 text-muted-foreground"/>
                   <h2 className="text-lg font-medium">{videoPlayerProps.title}</h2>
@@ -1082,7 +1082,7 @@ export default function EventsPage() {
                   Camera: {videoPlayerProps.deviceName}
                 </p>
               )}
-              <div className="relative flex-grow w-full min-h-0 p-4">
+              <div className="relative grow w-full min-h-0 p-4">
                                  <PikoVideoPlayer 
                    connectorId={videoPlayerProps.connectorId || ''}
                    pikoSystemId={videoPlayerProps.pikoSystemId || undefined}
@@ -1369,17 +1369,17 @@ export default function EventsPage() {
 
         {/* Show skeleton when loading AND preferences are initialized */}
         {(isLoadingEvents || !eventsHasInitiallyLoaded) && preferencesInitialized ? (
-          <div className="flex-shrink-0">
+          <div className="shrink-0">
             {viewMode === 'card' 
               ? <EventCardViewSkeleton segmentCount={2} cardsPerSegment={4} cardSize={cardSize} />
               : <EventsTableSkeleton rowCount={15} columnCount={columns.length} />}
           </div>
         ) : (isLoadingEvents || !eventsHasInitiallyLoaded) && !preferencesInitialized ? (
           /* Don't show any skeleton while preferences are loading to avoid race condition */
-          <div className="flex-shrink-0"></div>
+          <div className="shrink-0"></div>
         ) : (
           /* Show content when loaded */
-          <div className="border rounded-md flex-grow overflow-hidden flex flex-col">
+          <div className="border rounded-md grow overflow-hidden flex flex-col">
             {viewMode === 'table' ? (
               <EventsTableView 
                 table={table} 
@@ -1397,7 +1397,7 @@ export default function EventsPage() {
               displayedEvents.length > 0 ? (
                 <EventCardView events={displayedEvents} spaces={spaces} allDevices={allDevices} cardSize={cardSize} onPlayVideo={handlePlayVideo} />
               ) : (
-                <div className="flex-grow flex items-center justify-center p-4">
+                <div className="grow flex items-center justify-center p-4">
                   <div className="text-center">
                     <p className="text-muted-foreground">
                       No events match your current filters.

--- a/src/app/(features)/locations/page.tsx
+++ b/src/app/(features)/locations/page.tsx
@@ -420,7 +420,7 @@ export default function LocationsPage() {
                       <Skeleton className="h-5 w-28 rounded" />
                       <Skeleton className="h-5 w-16 rounded-full" />
                     </div>
-                    <div className="flex items-center gap-1 flex-shrink-0">
+                    <div className="flex items-center gap-1 shrink-0">
                       <Skeleton className="h-7 w-7 rounded-md" />
                     </div>
                   </CardHeader>
@@ -514,7 +514,7 @@ export default function LocationsPage() {
   // Define page actions
   const pageActions = (
     <>
-      <div className="relative flex-shrink-0">
+      <div className="relative shrink-0">
         <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
         <Input
           type="search"
@@ -570,7 +570,7 @@ export default function LocationsPage() {
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <div className="flex flex-col h-full"> 
-        <div className="p-4 border-b flex-shrink-0">
+        <div className="p-4 border-b shrink-0">
           <PageHeader 
             title="Locations & Spaces"
             icon={(
@@ -591,7 +591,7 @@ export default function LocationsPage() {
           />
         </div>
 
-        <div className="flex flex-grow overflow-hidden"> 
+        <div className="flex grow overflow-hidden"> 
           {showTreeView && (
             <LocationTreeView
               locations={locations}
@@ -644,11 +644,11 @@ export default function LocationsPage() {
                                       >
                                           <div className="flex items-center gap-2 min-w-0">
                                             {isCollapsed ? (
-                                              <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                                              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
                                             ) : (
-                                              <ChevronDown className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                                              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
                                             )}
-                                            <Building className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                            <Building className="h-4 w-4 text-muted-foreground shrink-0" />
                                             <div className="flex flex-col min-w-0">
                                               <div className="flex items-center gap-2 min-w-0">
                                                 <CardTitle className="text-base font-medium truncate" title={location.name}>{location.name}</CardTitle>
@@ -668,9 +668,9 @@ export default function LocationsPage() {
                                              )}
                                            </div>
                                          </div>
-                                          <div className="relative flex items-center gap-1 flex-shrink-0 -translate-y-0.5">
+                                          <div className="relative flex items-center gap-1 shrink-0 -translate-y-0.5">
                                             <div onClick={(e) => e.stopPropagation()}>
-                                              <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs flex-shrink-0">
+                                              <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs shrink-0">
                                                 {filteredSpaces.length} {filteredSpaces.length === 1 ? 'Space' : 'Spaces'}
                                               </Badge>
                                             </div>

--- a/src/app/(features)/system-logs/page.tsx
+++ b/src/app/(features)/system-logs/page.tsx
@@ -178,7 +178,7 @@ export default function SystemLogsPage() {
         connectionStatus === 'connecting' ? "secondary" :
         "destructive" // error state
       } className="h-8 px-3 flex items-center gap-1.5 w-28 justify-center pointer-events-none">
-        <span className={`h-2 w-2 rounded-full inline-flex flex-shrink-0 animate-pulse ${
+        <span className={`h-2 w-2 rounded-full inline-flex shrink-0 animate-pulse ${
           connectionStatus === 'paused' ? 'bg-gray-500' :
           connectionStatus === 'connected' ? 'bg-green-400 ring-1 ring-white' :
           connectionStatus === 'connecting' ? 'bg-yellow-400 ring-1 ring-white' :
@@ -203,7 +203,7 @@ export default function SystemLogsPage() {
         <CardHeader className="flex-none pb-4 border-b"> {/* Add border back */} 
           <div className="flex items-start justify-between gap-4">
             {/* Title/Description Section */}
-            <div className="flex items-center gap-4 flex-shrink-0">
+            <div className="flex items-center gap-4 shrink-0">
               <Terminal className="h-6 w-6 text-muted-foreground" />
               <div>
                 <CardTitle className="text-xl">System Logs</CardTitle> {/* Adjusted size */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,7 @@ export default function Home() {
                           variant="ghost" 
                           size="icon" 
                           onClick={() => handleDelete(connector.id)}
-                          className="text-destructive hover:text-destructive hover:bg-destructive/10 h-8 w-8 flex-shrink-0"
+                          className="text-destructive hover:text-destructive hover:bg-destructive/10 h-8 w-8 shrink-0"
                         >
                           <Trash2 className="h-4 w-4" />
                           <span className="sr-only">Delete</span>

--- a/src/components/common/LocationSpaceSelector.tsx
+++ b/src/components/common/LocationSpaceSelector.tsx
@@ -64,8 +64,8 @@ export function LocationSpaceSelector({
       if (selectedSpace && selectedLocation) {
         return (
           <div className="flex items-center gap-1.5 min-w-0">
-            <Box className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-            <span className="font-medium flex-shrink-0">
+            <Box className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="font-medium shrink-0">
               {selectedSpace.name}
             </span>
             <span className="text-xs text-muted-foreground truncate">
@@ -79,7 +79,7 @@ export function LocationSpaceSelector({
       if (selectedLocation) {
         return (
           <div className="flex items-center gap-2">
-            <Building className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+            <Building className="h-4 w-4 text-muted-foreground shrink-0" />
             <span className="truncate">{selectedLocation.name}</span>
           </div>
         );
@@ -87,7 +87,7 @@ export function LocationSpaceSelector({
     }
     return (
       <div className="flex items-center gap-2">
-        <Building className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        <Building className="h-4 w-4 text-muted-foreground shrink-0" />
         <span className="font-semibold">All</span>
       </div>
     );

--- a/src/components/common/timezone-selector.tsx
+++ b/src/components/common/timezone-selector.tsx
@@ -132,7 +132,7 @@ export const TimezoneSelector: React.FC<TimezoneSelectorProps> = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent 
-        className="w-[--radix-popover-trigger-width] max-h-[--radix-popover-content-available-height] p-0"
+        className="w-(--radix-popover-trigger-width) max-h-(--radix-popover-content-available-height) p-0"
         onWheel={(e) => e.stopPropagation()} 
       >
         <Command>

--- a/src/components/features/account/pin-management-dialog.tsx
+++ b/src/components/features/account/pin-management-dialog.tsx
@@ -203,7 +203,7 @@ export function PinManagementDialog({ user, isOpen, onOpenChange, isSelfService 
           <div className="py-6">
             <div className="p-4 bg-red-50 rounded-lg border border-red-200">
               <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-6 h-6 bg-red-100 rounded-full flex items-center justify-center mt-0.5">
+                <div className="shrink-0 w-6 h-6 bg-red-100 rounded-full flex items-center justify-center mt-0.5">
                   <Trash2 className="h-3.5 w-3.5 text-red-600" />
                 </div>
                 <div>

--- a/src/components/features/account/user-organizations-dialog.tsx
+++ b/src/components/features/account/user-organizations-dialog.tsx
@@ -190,7 +190,7 @@ export function UserOrganizationsDialog({
                         key={item.membership.id}
                         className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors"
                       >
-                        <div className="flex-shrink-0">
+                        <div className="shrink-0">
                           <OrganizationLogoDisplay
                             logo={item.organization.logo}
                             className="h-10 w-10 rounded-md"

--- a/src/components/features/ai-assistant/ChatAIAssistant.tsx
+++ b/src/components/features/ai-assistant/ChatAIAssistant.tsx
@@ -356,7 +356,7 @@ export function ChatAIAssistant({ onResults }: ChatAIAssistantProps) {
           size="lg"
           className="h-14 w-14 min-w-14 rounded-full shadow-lg hover:shadow-2xl transition-all duration-300 ai-gradient ai-gradient-hover border-0 ring-2 ring-white/10 hover:ring-white/20 hover:scale-105 active:scale-95 p-0 flex items-center justify-center"
         >
-          <MessagesSquare className="!h-6 !w-6 text-white drop-shadow-sm" />
+          <MessagesSquare className="h-6! w-6! text-white drop-shadow-sm" />
           <span className="sr-only">AI Assistant</span>
         </Button>
       </div>
@@ -385,7 +385,7 @@ export function ChatAIAssistant({ onResults }: ChatAIAssistantProps) {
             : "animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-200"
         )}
       >
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 ai-gradient rounded-t-lg flex-shrink-0">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 ai-gradient rounded-t-lg shrink-0">
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <MessagesSquare className="h-5 w-5" />
             AI Assistant

--- a/src/components/features/automations/AutomationCardView.tsx
+++ b/src/components/features/automations/AutomationCardView.tsx
@@ -123,7 +123,7 @@ function AutomationCardSkeleton() {
         <Card key={index} className="overflow-hidden">
           <div className="pb-2 border-b p-4">
             {/* Grid layout matching the actual card header */}
-            <div className="grid grid-cols-[1fr,auto] gap-2 w-full">
+            <div className="grid grid-cols-[1fr_auto] gap-2 w-full">
               {/* Title area with truncation - MATCHES ACTUAL COMPONENT */}
               <div className="flex items-center space-x-2 overflow-hidden">
                 <div className="overflow-hidden">
@@ -534,7 +534,7 @@ function AutomationCard({ automation, refreshData, connectors, targetDevices, lo
       <Card className="overflow-hidden hover:shadow-md transition-shadow">
         <CardHeader className="p-4 border-b">
           {/* Using grid for reliable layout with truncation */}
-          <div className="grid grid-cols-[1fr,auto] gap-2 w-full">
+          <div className="grid grid-cols-[1fr_auto] gap-2 w-full">
             {/* Title area with truncation */}
             <div className="flex items-center space-x-2 overflow-hidden">
               <div className="overflow-hidden">

--- a/src/components/features/automations/RuleBuilder.tsx
+++ b/src/components/features/automations/RuleBuilder.tsx
@@ -378,7 +378,7 @@ export function RuleBuilder({
                         </SelectContent>
                     </Select>
                     <span className="text-xs text-muted-foreground">of the following must be true:</span>
-                    <div className="flex-grow"></div> {/* Spacer */} 
+                    <div className="grow"></div> {/* Spacer */} 
                     {depth > 0 && onRemove && (
                         <Button type="button" variant="ghost" size="icon" className="h-6 w-6 text-muted-foreground hover:text-destructive" onClick={onRemove}>
                             <Trash2 className="h-4 w-4" />

--- a/src/components/features/automations/TokenInserter.tsx
+++ b/src/components/features/automations/TokenInserter.tsx
@@ -67,10 +67,10 @@ export function TokenInserter({ tokens, onInsert, className }: TokenInserterProp
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-80 h-[560px] p-0 flex flex-col" align="end">
-                <div className="p-3 text-sm font-semibold border-b flex-shrink-0">Available Tokens</div>
+                <div className="p-3 text-sm font-semibold border-b shrink-0">Available Tokens</div>
                 
                 {/* Search Input */}
-                <div className="p-3 border-b flex-shrink-0">
+                <div className="p-3 border-b shrink-0">
                     <div className="relative">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                         <Input
@@ -82,7 +82,7 @@ export function TokenInserter({ tokens, onInsert, className }: TokenInserterProp
                     </div>
                 </div>
 
-                <ScrollArea className="flex-grow">
+                <ScrollArea className="grow">
                     <div className="p-2">
                         {Object.keys(groupedTokens).length === 0 ? (
                             <div className="text-center text-muted-foreground text-sm py-4">

--- a/src/components/features/automations/actions/PlayAudioActionFields.tsx
+++ b/src/components/features/automations/actions/PlayAudioActionFields.tsx
@@ -56,7 +56,7 @@ export function PlayAudioActionFields({ form, actionIndex, devices, isLoading, o
                   return (
                     <SelectItem key={device.id} value={device.id}>
                       <div className="flex items-center">
-                        <IconComponent className="h-4 w-4 mr-2 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
+                        <IconComponent className="h-4 w-4 mr-2 shrink-0 text-muted-foreground" aria-hidden="true" />
                         <span>{device.name}</span>
                       </div>
                     </SelectItem>
@@ -125,7 +125,7 @@ export function PlayAudioActionFields({ form, actionIndex, devices, isLoading, o
           control={form.control}
           name={`config.actions.${actionIndex}.params.volumeTemplate`}
           render={({ field, fieldState }) => (
-            <FormItem className="flex-grow">
+            <FormItem className="grow">
               <FormLabel>Volume (Optional)</FormLabel>
               <FormControl>
                 <Input {...field} disabled={!!isLoading} placeholder="1-100" type="number" min="1" max="100" className={cn('w-[120px]', fieldState.error && (fieldState.isTouched || form.formState.isSubmitted) && 'border-destructive')} />
@@ -139,7 +139,7 @@ export function PlayAudioActionFields({ form, actionIndex, devices, isLoading, o
           control={form.control}
           name={`config.actions.${actionIndex}.params.repeatTemplate`}
           render={({ field, fieldState }) => (
-            <FormItem className="flex-grow">
+            <FormItem className="grow">
               <FormLabel>Repeat (Optional)</FormLabel>
               <FormControl>
                 <Input {...field} disabled={!!isLoading} placeholder="0-10" type="number" min="0" max="10" className={cn('w-[120px]', fieldState.error && (fieldState.isTouched || form.formState.isSubmitted) && 'border-destructive')} />

--- a/src/components/features/automations/actions/SendHttpRequestActionFields.tsx
+++ b/src/components/features/automations/actions/SendHttpRequestActionFields.tsx
@@ -136,7 +136,7 @@ export function SendHttpRequestActionFields({ form, actionIndex, handleInsertTok
     return (
         <div className="space-y-4">
             {/* URL + Method Field Row - Standardized Structure Above Controls */}
-            <div className="grid grid-cols-[120px,1fr] gap-4 items-start">
+            <div className="grid grid-cols-[120px_1fr] gap-4 items-start">
                 {/* Method Field */}
                 <FormField control={form.control} name={paramFieldName('method')} render={({ field }) => (
                     <FormItem>
@@ -163,7 +163,7 @@ export function SendHttpRequestActionFields({ form, actionIndex, handleInsertTok
                                 ))}
                             </SelectContent>
                         </Select>
-                        <FormMessage className="text-xs min-h-[1rem] mt-1"/> {/* Consistent spacing */}
+                        <FormMessage className="text-xs min-h-4 mt-1"/> {/* Consistent spacing */}
                     </FormItem>
                 )} />
                 
@@ -185,7 +185,7 @@ export function SendHttpRequestActionFields({ form, actionIndex, handleInsertTok
                              {/* TokenInserter is now a sibling to FormControl */} 
                             <TokenInserter tokens={AVAILABLE_AUTOMATION_TOKENS} onInsert={insertUrlToken}/>
                         </div>
-                        <FormMessage className="text-xs min-h-[1rem] mt-1"/> 
+                        <FormMessage className="text-xs min-h-4 mt-1"/> 
                     </FormItem>
                 )} />
             </div>

--- a/src/components/features/automations/actions/SetDeviceStateActionFields.tsx
+++ b/src/components/features/automations/actions/SetDeviceStateActionFields.tsx
@@ -32,7 +32,7 @@ export function SetDeviceStateActionFields({ form, actionIndex, devices, allLoca
           control={form.control}
           name={`config.actions.${actionIndex}.params.targetDeviceInternalId`}
           render={({ field, fieldState }) => (
-            <FormItem className="flex-grow-0 m-0">
+            <FormItem className="grow-0 m-0">
               <DeviceSelectorCombo
                 value={field.value}
                 onChange={field.onChange}
@@ -57,7 +57,7 @@ export function SetDeviceStateActionFields({ form, actionIndex, devices, allLoca
           control={form.control}
           name={`config.actions.${actionIndex}.params.targetState`}
           render={({ field, fieldState }) => (
-            <FormItem className="flex-grow-0 m-0">
+            <FormItem className="grow-0 m-0">
               <Select onValueChange={field.onChange} value={field.value ?? ''} disabled={!!isLoading}>
                 <FormControl>
                   <SelectTrigger className={cn('w-[120px]', fieldState.error && (fieldState.isTouched || form.formState.isSubmitted) && 'border-destructive')}>

--- a/src/components/features/automations/controls/TargetConnectorSelect.tsx
+++ b/src/components/features/automations/controls/TargetConnectorSelect.tsx
@@ -27,7 +27,7 @@ export function TargetConnectorSelect({ value, onChange, connectors, isLoading, 
           <SelectValue placeholder="Select Target Connector">
             {selected && (
               <div className="flex items-center gap-2">
-                <ConnectorIcon connectorCategory={selected.category} size={18} className="mr-1 flex-shrink-0" />
+                <ConnectorIcon connectorCategory={selected.category} size={18} className="mr-1 shrink-0" />
                 <span className="truncate">{selected.name}</span>
               </div>
             )}
@@ -39,7 +39,7 @@ export function TargetConnectorSelect({ value, onChange, connectors, isLoading, 
         {connectors.map(connector => (
           <SelectItem key={connector.id} value={connector.id} className="flex items-center py-1.5">
             <div className="flex items-center gap-2">
-              <ConnectorIcon connectorCategory={connector.category} size={16} className="flex-shrink-0" />
+              <ConnectorIcon connectorCategory={connector.category} size={16} className="shrink-0" />
               <span className="font-medium">{connector.name}</span>
             </div>
           </SelectItem>

--- a/src/components/features/automations/form-sections/ActionItem.tsx
+++ b/src/components/features/automations/form-sections/ActionItem.tsx
@@ -265,7 +265,7 @@ export function ActionItem({
                     <div className="relative">
               <AccordionTrigger className="w-full p-0 hover:no-underline pr-6">
                   <div className="flex items-center w-full px-4 py-3 pr-14">
-                      <div className="flex items-center flex-shrink-0">
+                      <div className="flex items-center shrink-0">
                           <div className="flex items-center gap-1">
                               <ActionIcon />
                               <span className="text-sm font-semibold">{getActionTitle(actionType)}</span>
@@ -323,7 +323,7 @@ export function ActionItem({
                                                   return (
                                                       <SelectItem key={type} value={type} className="pl-6">
                                                           <div className="flex items-center gap-2">
-                                                              <IconComponent className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                                              <IconComponent className="h-4 w-4 text-muted-foreground shrink-0" />
                                                               <span>{getActionTitle(type)}</span>
                                                           </div>
                                                       </SelectItem>

--- a/src/components/features/common/camera-wall-dialog.tsx
+++ b/src/components/features/common/camera-wall-dialog.tsx
@@ -119,7 +119,7 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameraDevices }) => {
          return (
            <div key={device.id} className="overflow-hidden grid-item-container">
              <Card className="h-full w-full flex flex-col">
-               <CardHeader className="p-1.5 flex-shrink-0 border-b bg-muted/30 rounded-t-lg">
+               <CardHeader className="p-1.5 shrink-0 border-b bg-muted/30 rounded-t-lg">
                  <CardTitle 
                    className="text-xs font-medium truncate text-center" 
                    title={device.name}
@@ -127,7 +127,7 @@ const CameraGrid: React.FC<CameraGridProps> = ({ cameraDevices }) => {
                    {device.name}
                  </CardTitle>
                </CardHeader>
-               <CardContent className="p-0 flex-grow relative overflow-hidden rounded-b-lg"> 
+               <CardContent className="p-0 grow relative overflow-hidden rounded-b-lg"> 
                  <div className="absolute inset-0 p-2">
                    <PikoVideoPlayer
                      connectorId={device.connectorId}
@@ -156,15 +156,15 @@ export const CameraWallDialog: React.FC<CameraWallDialogProps> = ({
         className="max-w-none w-[95vw] h-[90vh] flex flex-col p-4 sm:p-6"
         onOpenAutoFocus={(e) => e.preventDefault()} // Prevent focus trap issues on first element
       >
-        <DialogHeader className="flex-shrink-0 pb-2 border-b mb-4">
+        <DialogHeader className="shrink-0 pb-2 border-b mb-4">
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         
-        <div className="flex-grow overflow-y-auto pr-2 -mr-2"> {/* Allow content to scroll */} 
+        <div className="grow overflow-y-auto pr-2 -mr-2"> {/* Allow content to scroll */} 
           <CameraGrid cameraDevices={cameraDevices} />
         </div>
 
-        <DialogFooter className="flex-shrink-0 pt-4 border-t mt-4">
+        <DialogFooter className="shrink-0 pt-4 border-t mt-4">
           <DialogClose asChild>
             <Button type="button" variant="secondary">Close</Button>
           </DialogClose>

--- a/src/components/features/connectors/add-connector-modal.tsx
+++ b/src/components/features/connectors/add-connector-modal.tsx
@@ -1093,7 +1093,7 @@ export function AddConnectorModal() {
                                       control={form.control}
                                       name="host"
                                       render={({ field, fieldState }) => (
-                                        <FormItem className="flex-grow">
+                                        <FormItem className="grow">
                                           <FormLabel>Host/URL</FormLabel>
                                           <FormControl>
                                             <Input 

--- a/src/components/features/devices/device-detail-dialog-content.tsx
+++ b/src/components/features/devices/device-detail-dialog-content.tsx
@@ -249,7 +249,7 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
     
     return displayState ? (
       <Badge variant="outline" className="inline-flex items-center gap-1 px-2 py-0.5 font-normal">
-        {React.createElement(getDisplayStateIcon(displayState)!, { className: "h-3 w-3 flex-shrink-0" })}
+        {React.createElement(getDisplayStateIcon(displayState)!, { className: "h-3 w-3 shrink-0" })}
         <span className="text-xs">{displayState}</span>
       </Badge>
     ) : (
@@ -297,7 +297,7 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
             </div>
             {/* Right side: Action Switch (Conditional) */}
             {isActionable && (
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <div className="flex items-center gap-2">
@@ -468,7 +468,7 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
                    monospace breakAll 
                    value={( 
                      <div className="flex items-center justify-between gap-2 w-full"> 
-                       <span className="flex-grow break-all">{device.deviceId}</span> 
+                       <span className="grow break-all">{device.deviceId}</span> 
                        <Button 
                          variant="ghost" 
                          size="icon" 

--- a/src/components/features/devices/device-mapping-dialog-content.tsx
+++ b/src/components/features/devices/device-mapping-dialog-content.tsx
@@ -183,7 +183,7 @@ export function DeviceMappingDialogContent() {
         <TabsContent value="identifiers" className="mt-2 data-[state=inactive]:hidden overflow-y-auto max-h-[60vh]">
           <div className="space-y-2 pt-0 pb-2">
             <div className="flex items-center justify-between gap-4">
-              <div className="flex-grow">
+              <div className="grow">
                 <Input
                   placeholder="Filter mappings..."
                   value={filterText}
@@ -198,7 +198,7 @@ export function DeviceMappingDialogContent() {
                 size="sm"
                 onValueChange={(value) => { if (value) setCategoryFilter(value); }}
                 aria-label="Filter by connector type"
-                className="flex-shrink-0"
+                className="shrink-0"
               >
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/src/components/features/events/EventCardView.tsx
+++ b/src/components/features/events/EventCardView.tsx
@@ -107,7 +107,7 @@ export const EventCardView: React.FC<EventCardViewProps> = ({ events, allDevices
 
   if (!events || events.length === 0) {
     return (
-      <div className="flex-grow flex items-center justify-center p-4">
+      <div className="grow flex items-center justify-center p-4">
         <p className="text-muted-foreground">
             No events have been received yet. This page will update periodically.
         </p>
@@ -118,14 +118,14 @@ export const EventCardView: React.FC<EventCardViewProps> = ({ events, allDevices
   if (timeSegments.length === 0 && events.length > 0) {
      // Handle the case where processing might be happening or resulted in no segments
      return (
-        <div className="flex-grow flex items-center justify-center p-4">
+        <div className="grow flex items-center justify-center p-4">
             <p className="text-muted-foreground">Processing events...</p>
         </div>
      );
   }
 
   return (
-    <ScrollArea className="flex-grow h-full">
+    <ScrollArea className="grow h-full">
       <div className="p-4 space-y-6">
         {timeSegments.map((segment, segIndex) => {
           return (
@@ -134,7 +134,7 @@ export const EventCardView: React.FC<EventCardViewProps> = ({ events, allDevices
                 <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide whitespace-nowrap">
                   {segment.label}
                 </h3>
-                <div className="flex-grow border-t border-border ml-4"></div>
+                <div className="grow border-t border-border ml-4"></div>
               </div>
               <div className={gridClasses}>
                 {segment.groups.map((group) => {

--- a/src/components/features/events/EventGroupCard.tsx
+++ b/src/components/features/events/EventGroupCard.tsx
@@ -275,7 +275,7 @@ export const EventGroupCard: React.FC<EventGroupCardProps> = ({ group, allDevice
         "shadow-md hover:shadow-lg"
       )}>
         <CardHeader className={cn(
-          "p-3 flex-shrink-0"
+          "p-3 shrink-0"
         )}>
           <div className="flex justify-between items-start gap-2">
             <div className="min-w-0">
@@ -418,7 +418,7 @@ export const EventGroupCard: React.FC<EventGroupCardProps> = ({ group, allDevice
                       <PopoverTrigger asChild>
                         <Badge
                           variant="secondary"
-                          className="text-[10px] h-4 px-1 bg-black/60 hover:bg-black/70 backdrop-blur-sm text-white flex-shrink-0 flex items-center gap-1 cursor-pointer"
+                          className="text-[10px] h-4 px-1 bg-black/60 hover:bg-black/70 backdrop-blur-sm text-white shrink-0 flex items-center gap-1 cursor-pointer"
                         >
                           {DeviceIcon && <DeviceIcon className="h-3 w-3" />}
                           {EVENT_TYPE_DISPLAY_MAP[firstEventType] ?? firstEventType}
@@ -426,10 +426,10 @@ export const EventGroupCard: React.FC<EventGroupCardProps> = ({ group, allDevice
                         </Badge>
                       </PopoverTrigger>
                       <PopoverContent side="top" align="end" className="w-72 p-0 shadow-xl flex flex-col">
-                        <div className="p-3 flex-shrink-0">
+                        <div className="p-3 shrink-0">
                           <p className="font-medium text-sm mb-2">Event Sequence</p>
                         </div>
-                        <ScrollArea className="flex-grow min-h-0 w-full" type="scroll">
+                        <ScrollArea className="grow min-h-0 w-full" type="scroll">
                           <div className="px-3 pb-3">
                             <div className="relative border-l border-muted ml-1.5 pl-4 space-y-2">
                               {events.map((event) => {
@@ -448,7 +448,7 @@ export const EventGroupCard: React.FC<EventGroupCardProps> = ({ group, allDevice
                                       </div>
                                       <div className="flex items-start gap-1 mb-1">
                                         <DeviceIcon className="h-4 w-4 text-muted-foreground mt-0.5" />
-                                        <div className="flex-grow min-w-0">
+                                        <div className="grow min-w-0">
                                           <div className="font-medium truncate">{event.deviceName || event.deviceId}</div>
                                           <div className="flex items-center flex-wrap gap-1 mt-0.5">
                                             {(event.eventType === EventType.STATE_CHANGED && event.displayState && StateIcon) ? (

--- a/src/components/features/events/EventHierarchyViewer.tsx
+++ b/src/components/features/events/EventHierarchyViewer.tsx
@@ -93,7 +93,7 @@ export const EventHierarchyViewer: React.FC = () => {
     return (
         <div className="flex flex-col h-[calc(60vh+40px)]"> 
             {/* --- Single Toggle Button --- */}
-            <div className="flex items-center justify-end gap-2 mb-2 px-1 flex-shrink-0">
+            <div className="flex items-center justify-end gap-2 mb-2 px-1 shrink-0">
                 <Button variant="outline" size="sm" onClick={toggleAll} className="text-xs h-7">
                     {allExpanded ? (
                         <MinusSquare className="h-3.5 w-3.5" />
@@ -105,7 +105,7 @@ export const EventHierarchyViewer: React.FC = () => {
             </div>
             {/* --- End Single Toggle Button --- */}
 
-            <ScrollArea className="flex-grow pr-4"> 
+            <ScrollArea className="grow pr-4"> 
                 <div className="space-y-1"> 
                     {sortedHierarchyEntries.map(([categoryKey, categoryData], index) => {
                         const IconComponent = getEventCategoryIcon(categoryKey as EventCategory);

--- a/src/components/features/events/EventTimeline.tsx
+++ b/src/components/features/events/EventTimeline.tsx
@@ -142,7 +142,7 @@ export function EventTimeline({ events, allDevices }: EventTimelineProps) {
 
   return (
     <TooltipProvider delayDuration={100}>
-      <div className="relative space-y-8 before:absolute before:inset-0 before:ml-5 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-slate-300 before:to-transparent dark:before:via-slate-700">
+      <div className="relative space-y-8 before:absolute before:inset-0 before:ml-5 before:h-full before:w-0.5 before:bg-linear-to-b before:from-transparent before:via-slate-300 before:to-transparent dark:before:via-slate-700">
         {groupedEvents.map((group) => {
 
           // Find Piko Camera for this group's space
@@ -156,7 +156,7 @@ export function EventTimeline({ events, allDevices }: EventTimelineProps) {
             {/* Group Header / Time Marker */}
             <div className="flex items-start mb-4">
                 {/* Icon container */}
-                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center shadow-md">
+                <div className="shrink-0 w-10 h-10 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center shadow-md">
                     {thumbnailUrl ? (
                         <Camera className="w-5 h-5 text-slate-600 dark:text-slate-300" />
                     ) : (
@@ -164,7 +164,7 @@ export function EventTimeline({ events, allDevices }: EventTimelineProps) {
                     )}
                 </div>
                 {/* Text content */}
-                <div className="ml-4 flex-grow">
+                <div className="ml-4 grow">
                    <h3 className="text-lg font-semibold">
                        {group.spaceName ? (
                            <>
@@ -193,7 +193,7 @@ export function EventTimeline({ events, allDevices }: EventTimelineProps) {
                 </div>
                  {/* Thumbnail (if exists) */}
                  {thumbnailUrl && (
-                     <div className="ml-4 flex-shrink-0 w-24 h-16 relative rounded overflow-hidden shadow-md">
+                     <div className="ml-4 shrink-0 w-24 h-16 relative rounded overflow-hidden shadow-md">
                          <Image
                              src={thumbnailUrl}
                              alt={`Camera view for ${group.spaceName || 'space'} around ${format(group.endTime, 'p')}`}

--- a/src/components/features/events/EventsTableView.tsx
+++ b/src/components/features/events/EventsTableView.tsx
@@ -109,7 +109,7 @@ export function EventsTableView<TData extends TableEventData>({
   return (
     <>
       {/* Inner container for scrollable table */}
-      <div className="flex-grow overflow-auto">
+      <div className="grow overflow-auto">
         <Table>
           <TableHeader className="sticky top-0 bg-background z-10">
             {table.getHeaderGroups().map((headerGroup) => (
@@ -208,7 +208,7 @@ export function EventsTableView<TData extends TableEventData>({
         </Table>
       </div>
       {/* Pagination */}
-      <div className="flex items-center justify-between p-2 border-t flex-shrink-0">
+      <div className="flex items-center justify-between p-2 border-t shrink-0">
         <div className="flex-1 text-sm text-muted-foreground">
           Total Rows: {table.getFilteredRowModel().rows.length}
         </div>

--- a/src/components/features/events/TimeFilterDropdown.tsx
+++ b/src/components/features/events/TimeFilterDropdown.tsx
@@ -164,7 +164,7 @@ export function TimeFilterDropdown({
       <DropdownMenuTrigger asChild>
         <Button variant="outline" className={className || "w-full sm:w-[160px] h-9 justify-between"}>
           <div className="flex items-center gap-2 flex-1 min-w-0">
-            <Clock className="h-4 w-4 flex-shrink-0" />
+            <Clock className="h-4 w-4 shrink-0" />
             {tooltipText ? (
               <TooltipProvider delayDuration={200}>
                 <Tooltip>

--- a/src/components/features/events/event-card-skeleton.tsx
+++ b/src/components/features/events/event-card-skeleton.tsx
@@ -17,7 +17,7 @@ export const EventCardSkeleton: React.FC<EventCardSkeletonProps> = ({ cardSize =
 
   return (
     <Card className={cn("overflow-hidden flex flex-col border-l-4 border-transparent")}>
-      <CardHeader className="p-3 flex-shrink-0">
+      <CardHeader className="p-3 shrink-0">
         <Skeleton className="h-5 w-3/4 mb-1.5" />
         <Skeleton className="h-3 w-1/2" />
       </CardHeader>

--- a/src/components/features/events/event-card-view-skeleton.tsx
+++ b/src/components/features/events/event-card-view-skeleton.tsx
@@ -37,7 +37,7 @@ export const EventCardViewSkeleton: React.FC<EventCardViewSkeletonProps> = ({
           {/* Section header skeleton matching the real structure */}
           <div className="flex items-center mb-3 py-2">
             <Skeleton className="h-4 w-20" />
-            <div className="flex-grow border-t border-border ml-4"></div>
+            <div className="grow border-t border-border ml-4"></div>
           </div>
           <div className={gridClasses}>
             {[...Array(cardsPerSegment)].map((_, cardIndex) => (

--- a/src/components/features/events/event-detail-dialog-content.tsx
+++ b/src/components/features/events/event-detail-dialog-content.tsx
@@ -263,7 +263,7 @@ export const EventDetailDialogContent: React.FC<EventDetailDialogContentProps> =
       <DialogHeader className="pb-4 border-b">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <DeviceIcon className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+              <DeviceIcon className="h-5 w-5 text-muted-foreground shrink-0" />
               <DialogTitle>
                 {EVENT_TYPE_DISPLAY_MAP[currentEvent.eventType as EventType] || currentEvent.eventType || currentEvent.eventCategory || 'Event Details'}
               </DialogTitle>
@@ -397,7 +397,7 @@ export const EventDetailDialogContent: React.FC<EventDetailDialogContentProps> =
                         key: 'Device Type',
                         value: (
                           <Badge variant="secondary" className="inline-flex items-center gap-1.5 pl-1.5 pr-2 py-0.5 font-normal">
-                            <DeviceIcon className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                            <DeviceIcon className="h-3 w-3 text-muted-foreground shrink-0" />
                             <span className="text-xs">
                               {typeInfo.type}
                               {typeInfo.subtype && (
@@ -501,7 +501,7 @@ export const EventDetailDialogContent: React.FC<EventDetailDialogContentProps> =
                               label="State" 
                               value={
                                 <Badge variant="outline" className="inline-flex items-center gap-1.5 py-0.5 px-2 font-normal">
-                                  {React.createElement(StateIcon, { className: "h-3 w-3 flex-shrink-0" })}
+                                  {React.createElement(StateIcon, { className: "h-3 w-3 shrink-0" })}
                                   {currentEvent.displayState}
                                 </Badge>
                               } 

--- a/src/components/features/events/image-preview-dialog.tsx
+++ b/src/components/features/events/image-preview-dialog.tsx
@@ -162,7 +162,7 @@ export const ImagePreviewDialog: React.FC<ImagePreviewDialogProps> = ({
           </div>
 
           {/* Floating toolbar (top-right) */}
-          <div className="absolute top-2 right-3 z-[61] pointer-events-none">
+          <div className="absolute top-2 right-3 z-61 pointer-events-none">
             <TooltipProvider>
               <div className="pointer-events-auto inline-flex items-center gap-1 rounded-md bg-background/80 backdrop-blur-sm border px-1.5 py-1">
                 

--- a/src/components/features/events/video-playback-dialog.tsx
+++ b/src/components/features/events/video-playback-dialog.tsx
@@ -70,7 +70,7 @@ export const VideoPlaybackDialog: React.FC<VideoPlaybackDialogProps> = React.mem
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {/* Increased width for video, aspect ratio handled by player */}
       <DialogContent className="sm:max-w-[80vw] md:max-w-[70vw] lg:max-w-[60vw] xl:max-w-[50vw] p-0 flex flex-col max-h-[90vh]">
-        <DialogHeader className="p-4 pb-2 space-y-0 flex-shrink-0">
+        <DialogHeader className="p-4 pb-2 space-y-0 shrink-0">
           <div className="flex flex-row items-center justify-between">
             <div className="flex items-center gap-2">
               <Video className="h-5 w-5 text-muted-foreground"/>
@@ -96,7 +96,7 @@ export const VideoPlaybackDialog: React.FC<VideoPlaybackDialogProps> = React.mem
             )}
           </div>
         )}
-        <div className="relative flex-grow w-full min-h-0 px-4"> {/* Ensure player can take space and scroll if needed */}
+        <div className="relative grow w-full min-h-0 px-4"> {/* Ensure player can take space and scroll if needed */}
           <PikoVideoPlayer 
             connectorId={activeConnectorId}
             pikoSystemId={activePikoSystemId || undefined} // Pass undefined if null

--- a/src/components/features/linear/linear-comments-section.tsx
+++ b/src/components/features/linear/linear-comments-section.tsx
@@ -142,7 +142,7 @@ export function LinearCommentsSection({ comments, isLoading = false }: LinearCom
 
   const renderComment = (comment: LinearComment, isReply = false) => (
     <div key={comment.id} className={`flex gap-3 ${isReply ? 'ml-11' : ''}`}>
-      <Avatar className={`${isReply ? 'h-7 w-7' : 'h-8 w-8'} flex-shrink-0`}>
+      <Avatar className={`${isReply ? 'h-7 w-7' : 'h-8 w-8'} shrink-0`}>
         {comment.user.avatarUrl && (
           <AvatarImage src={comment.user.avatarUrl} alt={comment.user.name} />
         )}

--- a/src/components/features/linear/linear-issue-detail-dialog.tsx
+++ b/src/components/features/linear/linear-issue-detail-dialog.tsx
@@ -277,7 +277,7 @@ export function LinearIssueDetailDialog({
         <div className="flex h-full overflow-hidden">
           {/* Main Content Area */}
           <div className="flex-1 flex flex-col min-w-0">
-            <DialogHeader className="px-8 py-6 border-b bg-muted/20 flex-shrink-0">
+            <DialogHeader className="px-8 py-6 border-b bg-muted/20 shrink-0">
               <div className="flex items-center gap-3 mb-4">
                 <span className="font-mono text-sm text-muted-foreground">
                   {localIssue.team.name}
@@ -329,7 +329,7 @@ export function LinearIssueDetailDialog({
           </div>
 
           {/* Properties Sidebar */}
-          <div className="w-80 flex-shrink-0 border-l bg-muted/10 overflow-y-auto">
+          <div className="w-80 shrink-0 border-l bg-muted/10 overflow-y-auto">
             <div className="p-6 space-y-6">
               <div className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
                 Properties

--- a/src/components/features/locations/alarm-zones/AlarmZoneCard.tsx
+++ b/src/components/features/locations/alarm-zones/AlarmZoneCard.tsx
@@ -86,17 +86,17 @@ export const AlarmZoneCard: React.FC<AlarmZoneCardProps> = ({
       >
          <div className="flex items-center gap-2 min-w-0">
            {isDevicesExpanded ? 
-               <ChevronDown className="h-4 w-4 flex-shrink-0 text-muted-foreground" /> : 
-               <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+               <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : 
+               <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
            }
-          <Shield className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+          <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
           <CardTitle className="text-base font-medium truncate" title={zone.name}>{zone.name}</CardTitle>
-          <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs ml-2 flex-shrink-0">
+          <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs ml-2 shrink-0">
             {deviceCount} {deviceCount === 1 ? 'Device' : 'Devices'}
           </Badge>
          </div>
          
-         <div className="relative flex items-center gap-1 flex-shrink-0 -translate-y-0.5">
+         <div className="relative flex items-center gap-1 shrink-0 -translate-y-0.5">
            {/* Armed State Dropdown Button */} 
            {onArmAction && (
              <DropdownMenu>

--- a/src/components/features/locations/alarm-zones/AlarmZoneDevicesSubRow.tsx
+++ b/src/components/features/locations/alarm-zones/AlarmZoneDevicesSubRow.tsx
@@ -63,7 +63,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
             {...attributes} 
         >
             <div className="flex items-center justify-between gap-1 min-w-0">
-                <span className="font-medium text-sm truncate flex-grow" title={device.name}>
+                <span className="font-medium text-sm truncate grow" title={device.name}>
                     {device.name}
                 </span>
                 <Dialog>
@@ -71,7 +71,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
                         <Button 
                             variant="ghost" 
                             size="icon" 
-                            className="h-6 w-6 flex-shrink-0 -mr-1 text-muted-foreground hover:text-foreground"
+                            className="h-6 w-6 shrink-0 -mr-1 text-muted-foreground hover:text-foreground"
                             title={`Details for ${device.name}`}
                         >
                             <Info className="h-3.5 w-3.5" />
@@ -100,7 +100,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <Badge variant="secondary" className="inline-flex items-center gap-1 pl-1 pr-1.5 py-0.5 font-normal min-w-0">
-                                <ConnectorIcon connectorCategory={device.connectorCategory} size={13} className="flex-shrink-0" />
+                                <ConnectorIcon connectorCategory={device.connectorCategory} size={13} className="shrink-0" />
                                 <span className="text-xs truncate">
                                     {typeText}
                                     {subtypeText && (
@@ -117,9 +117,9 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
                 </TooltipProvider>
                 <div className="flex items-center gap-1.5 min-w-0">
                     {StateIconComponent ? (
-                        <StateIconComponent className={cn("h-3.5 w-3.5 flex-shrink-0", stateColorClass)} />
+                        <StateIconComponent className={cn("h-3.5 w-3.5 shrink-0", stateColorClass)} />
                     ) : (
-                        <div className="h-3.5 w-3.5 flex-shrink-0" />
+                        <div className="h-3.5 w-3.5 shrink-0" />
                     )}
                     <span className={cn("truncate", stateColorClass)}> 
                         {displayState ?? 'State Unknown'}
@@ -188,7 +188,7 @@ export const AlarmZoneDevicesSubRow: React.FC<AlarmZoneDevicesSubRowProps> = ({
             <React.Fragment key={type}>
               <h5 key={`${type}-header`} className="text-xs font-semibold uppercase text-muted-foreground mb-2 tracking-wide flex items-center gap-2"> 
                  <GroupIcon className="h-3.5 w-3.5" /> 
-                 <span className="flex-grow">{type}</span>
+                 <span className="grow">{type}</span>
                  <Badge variant="secondary" className="px-1.5 py-0.5 text-xs font-medium"> 
                    {devicesInGroup.length}
                  </Badge>

--- a/src/components/features/locations/floor-plan/device-overlays/device-palette.tsx
+++ b/src/components/features/locations/floor-plan/device-overlays/device-palette.tsx
@@ -104,7 +104,7 @@ function DraggableDeviceItem({ device, isCompact = false, inList = false }: Drag
       {/* Hidden drag preview element */}
       <div
         ref={dragPreviewRef}
-        className="fixed -top-[1000px] -left-[1000px] pointer-events-none z-[9999]"
+        className="fixed -top-[1000px] -left-[1000px] pointer-events-none z-9999"
         aria-hidden
       >
         <div className="relative w-8 h-8">
@@ -137,7 +137,7 @@ function DraggableDeviceItem({ device, isCompact = false, inList = false }: Drag
               )}
             >
             {/* Device Icon */}
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <IconComponent className="h-4 w-4 text-muted-foreground" />
             </div>
             
@@ -159,14 +159,14 @@ function DraggableDeviceItem({ device, isCompact = false, inList = false }: Drag
             </div>
             
             {/* State Indicator */}
-            <div className="flex-shrink-0 flex items-center gap-1">
+            <div className="shrink-0 flex items-center gap-1">
               {StateIconComponent && (
                 <StateIconComponent className={cn("h-3 w-3", stateColorClass)} />
               )}
             </div>
             
              {/* Drag Handle Indicator */}
-            <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
               <div className="flex flex-col gap-0.5">
                 <div className="w-1 h-1 bg-muted-foreground/50 rounded-full"></div>
                 <div className="w-1 h-1 bg-muted-foreground/50 rounded-full"></div>
@@ -339,7 +339,7 @@ export function DevicePalette({
 
   return (
     <Card className={cn("h-full flex flex-col", className)}>
-      <CardHeader className="pb-3 sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+      <CardHeader className="pb-3 sticky top-0 z-10 bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 border-b">
         <div className="relative">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
@@ -422,7 +422,7 @@ export function DevicePalette({
                   }}
               >
                 <CollapsibleTrigger asChild>
-                  <div className="w-full sticky top-0 z-[1]">
+                  <div className="w-full sticky top-0 z-1">
                     <Button
                       variant="ghost"
                       className="w-full justify-between h-auto px-2 py-1.5 font-medium border border-transparent hover:border-border rounded-md"

--- a/src/components/features/locations/floor-plan/floor-plan-device-detail-sheet.tsx
+++ b/src/components/features/locations/floor-plan/floor-plan-device-detail-sheet.tsx
@@ -257,7 +257,7 @@ export function FloorPlanDeviceDetailSheet({
         }}
         className={cn(
           // Override default sm:max-w-sm and w-3/4 from the Sheet component
-          'sm:max-w-none md:max-w-none !w-[420px] sm:!w-[500px] !shadow-2xl p-0 grid grid-rows-[auto,1fr] overflow-hidden',
+          'sm:max-w-none md:max-w-none w-[420px]! sm:w-[500px]! shadow-2xl! p-0 grid grid-rows-[auto_1fr] overflow-hidden',
           className
         )}
       >
@@ -286,7 +286,7 @@ export function FloorPlanDeviceDetailSheet({
             onValueChange={(v) => setActiveTab(v as 'details' | 'events')}
             className="space-y-3"
           >
-            <div className="sticky top-0 z-20 -mx-3 px-3 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="sticky top-0 z-20 -mx-3 px-3 py-2 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
               <TabsList>
                 <TabsTrigger value="details">Details</TabsTrigger>
                 <TabsTrigger value="events" disabled={!device?.id}>Events</TabsTrigger>

--- a/src/components/features/locations/floor-plan/floor-plan-device-events-tab.tsx
+++ b/src/components/features/locations/floor-plan/floor-plan-device-events-tab.tsx
@@ -193,7 +193,7 @@ export function FloorPlanDeviceEventsTab({ deviceId, spaceCameras }: FloorPlanDe
                 >
                   <div className="flex items-start gap-3">
                     {hasThumb ? (
-                      <div className="relative h-12 w-16 flex-shrink-0 overflow-hidden rounded-sm border">
+                      <div className="relative h-12 w-16 shrink-0 overflow-hidden rounded-sm border">
                         <Image
                           src={thumbUrl!}
                           alt=""
@@ -212,7 +212,7 @@ export function FloorPlanDeviceEventsTab({ deviceId, spaceCameras }: FloorPlanDe
                         <div className="absolute inset-0 bg-black/0 group-hover:bg-black/15 transition-colors" />
                       </div>
                     ) : thumbUrl ? (
-                      <div className="h-12 w-16 flex-shrink-0 rounded-sm border bg-muted/30 grid place-items-center">
+                      <div className="h-12 w-16 shrink-0 rounded-sm border bg-muted/30 grid place-items-center">
                         <TooltipProvider delayDuration={150}>
                           <Tooltip>
                             <TooltipTrigger asChild>
@@ -226,7 +226,7 @@ export function FloorPlanDeviceEventsTab({ deviceId, spaceCameras }: FloorPlanDe
                         </TooltipProvider>
                       </div>
                     ) : (
-                      <div className="h-12 w-16 flex-shrink-0 rounded-sm border bg-muted/30 grid place-items-center">
+                      <div className="h-12 w-16 shrink-0 rounded-sm border bg-muted/30 grid place-items-center">
                         <CatIcon className="h-5 w-5 text-muted-foreground" />
                       </div>
                     )}

--- a/src/components/features/locations/floor-plan/floor-plan-manager.tsx
+++ b/src/components/features/locations/floor-plan/floor-plan-manager.tsx
@@ -273,7 +273,7 @@ export function FloorPlanManager({ locationId, expectedToHaveFloorPlans = false,
       />
       {/* Delete confirm dialog for actions menu */}
       {activeFloorPlan && isDeleteOpen && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center">
+        <div className="fixed inset-0 z-100 flex items-center justify-center">
           {/* Reuse AlertDialog from shadcn by toggling state in place of dedicated component to keep scope small */}
           <div className="bg-background border rounded-lg shadow-lg p-6 max-w-sm w-full mx-4">
             <h3 className="font-semibold mb-2">Delete Floor Plan</h3>

--- a/src/components/features/locations/floor-plan/floor-plan-other-spaces-list.tsx
+++ b/src/components/features/locations/floor-plan/floor-plan-other-spaces-list.tsx
@@ -39,7 +39,7 @@ export function FloorPlanOtherSpacesList({ devices, title = 'Other devices in th
                   {subtypeText ? <span> / {subtypeText}</span> : null}
                 </div>
               </div>
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 {displayState ? (
                   <Badge variant="outline" className="inline-flex items-center gap-1 px-1.5 py-0.5">
                     {DisplayIcon && <DisplayIcon className={cn('h-3 w-3', stateColorClass)} />}

--- a/src/components/features/locations/location-edit-dialog.tsx
+++ b/src/components/features/locations/location-edit-dialog.tsx
@@ -416,7 +416,7 @@ export const LocationEditDialog: React.FC<LocationEditDialogProps> = ({
                               </FormControl>
                             </PopoverTrigger>
                             <PopoverContent 
-                              className="w-[--radix-popover-trigger-width] max-h-[--radix-popover-content-available-height] p-0"
+                              className="w-(--radix-popover-trigger-width) max-h-(--radix-popover-content-available-height) p-0"
                               onWheel={(e) => e.stopPropagation()}
                             >
                               <Command>

--- a/src/components/features/locations/spaces/SpaceCard.tsx
+++ b/src/components/features/locations/spaces/SpaceCard.tsx
@@ -70,16 +70,16 @@ export const SpaceCard: React.FC<SpaceCardProps> = ({
       >
          <div className="flex items-center gap-2 min-w-0">
            {isDevicesExpanded ? 
-               <ChevronDown className="h-4 w-4 flex-shrink-0 text-muted-foreground" /> : 
-               <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+               <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : 
+               <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
            }
-          <Box className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+          <Box className="h-4 w-4 text-muted-foreground shrink-0" />
           <CardTitle className="text-base font-medium truncate" title={space.name}>{space.name}</CardTitle>
          </div>
          
-          <div className="relative flex items-center gap-1 flex-shrink-0 -translate-y-0.5">
+          <div className="relative flex items-center gap-1 shrink-0 -translate-y-0.5">
             <div onClick={(e) => e.stopPropagation()}>
-              <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs flex-shrink-0">
+              <Badge variant="outline" className="font-normal px-1.5 py-0.5 text-xs shrink-0">
                 {hasDevices ? `${deviceCount} Device${deviceCount !== 1 ? 's' : ''}` : 'No Devices'}
               </Badge>
             </div>

--- a/src/components/features/locations/spaces/SpaceDevicesSubRow.tsx
+++ b/src/components/features/locations/spaces/SpaceDevicesSubRow.tsx
@@ -63,7 +63,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
       {...attributes}
     >
       <div className="flex items-center justify-between gap-1 min-w-0">
-        <span className="font-medium text-sm truncate flex-grow" title={device.name}>
+        <span className="font-medium text-sm truncate grow" title={device.name}>
           {device.name}
         </span>
         <Dialog>
@@ -71,7 +71,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
             <Button 
               variant="ghost" 
               size="icon" 
-              className="h-6 w-6 flex-shrink-0 -mr-1 text-muted-foreground hover:text-foreground"
+              className="h-6 w-6 shrink-0 -mr-1 text-muted-foreground hover:text-foreground"
               title={`Details for ${device.name}`}
             >
               <Info className="h-3.5 w-3.5" />
@@ -100,7 +100,7 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
           <Tooltip>
             <TooltipTrigger asChild>
               <Badge variant="secondary" className="inline-flex items-center gap-1 pl-1 pr-1.5 py-0.5 font-normal min-w-0">
-                <ConnectorIcon connectorCategory={device.connectorCategory} size={13} className="flex-shrink-0" />
+                <ConnectorIcon connectorCategory={device.connectorCategory} size={13} className="shrink-0" />
                 <span className="text-xs truncate">
                   {typeText}
                   {subtypeText && (
@@ -117,9 +117,9 @@ const DraggableDeviceItem: React.FC<DraggableDeviceItemProps> = ({ device, sourc
         </TooltipProvider>
         <div className="flex items-center gap-1.5 min-w-0">
           {StateIconComponent ? (
-            <StateIconComponent className={cn("h-3.5 w-3.5 flex-shrink-0", stateColorClass)} />
+            <StateIconComponent className={cn("h-3.5 w-3.5 shrink-0", stateColorClass)} />
           ) : (
-            <div className="h-3.5 w-3.5 flex-shrink-0" />
+            <div className="h-3.5 w-3.5 shrink-0" />
           )}
           <span className={cn("truncate", stateColorClass)}> 
             {displayState ?? 'State Unknown'}
@@ -188,7 +188,7 @@ export const SpaceDevicesSubRow: React.FC<SpaceDevicesSubRowProps> = ({
             <React.Fragment key={type}>
               <h5 key={`${type}-header`} className="text-xs font-semibold uppercase text-muted-foreground mb-2 tracking-wide flex items-center gap-2"> 
                  <GroupIcon className="h-3.5 w-3.5" /> 
-                 <span className="flex-grow">{type}</span>
+                 <span className="grow">{type}</span>
                  <Badge variant="secondary" className="px-1.5 py-0.5 text-xs font-medium"> 
                    {devicesInGroup.length}
                  </Badge>

--- a/src/components/features/locations/spaces/space-camera-wall-dialog.tsx
+++ b/src/components/features/locations/spaces/space-camera-wall-dialog.tsx
@@ -119,7 +119,7 @@ const SpaceCameraGrid: React.FC<SpaceCameraGridProps> = ({ cameraDevices }) => {
          return (
            <div key={device.id} className="overflow-hidden grid-item-container">
              <Card className="h-full w-full flex flex-col">
-               <CardHeader className="p-1.5 flex-shrink-0 border-b bg-muted/30 rounded-t-lg">
+               <CardHeader className="p-1.5 shrink-0 border-b bg-muted/30 rounded-t-lg">
                  <CardTitle 
                    className="text-xs font-medium truncate text-center" 
                    title={device.name}
@@ -127,7 +127,7 @@ const SpaceCameraGrid: React.FC<SpaceCameraGridProps> = ({ cameraDevices }) => {
                    {device.name}
                  </CardTitle>
                </CardHeader>
-               <CardContent className="p-0 flex-grow relative overflow-hidden rounded-b-lg"> 
+               <CardContent className="p-0 grow relative overflow-hidden rounded-b-lg"> 
                  <div className="absolute inset-0 p-2">
                    <PikoVideoPlayer
                      connectorId={device.connectorId}
@@ -156,15 +156,15 @@ export const SpaceCameraWallDialog: React.FC<SpaceCameraWallDialogProps> = ({
         className="max-w-none w-[95vw] h-[90vh] flex flex-col p-4 sm:p-6"
         onOpenAutoFocus={(e) => e.preventDefault()} // Prevent focus trap issues on first element
       >
-        <DialogHeader className="flex-shrink-0 pb-2 border-b mb-4">
+        <DialogHeader className="shrink-0 pb-2 border-b mb-4">
           <DialogTitle>Camera Wall: {spaceName}</DialogTitle>
         </DialogHeader>
         
-        <div className="flex-grow overflow-y-auto pr-2 -mr-2"> {/* Allow content to scroll */} 
+        <div className="grow overflow-y-auto pr-2 -mr-2"> {/* Allow content to scroll */} 
           <SpaceCameraGrid cameraDevices={cameraDevices} />
         </div>
 
-        <DialogFooter className="flex-shrink-0 pt-4 border-t mt-4">
+        <DialogFooter className="shrink-0 pt-4 border-t mt-4">
           <DialogClose asChild>
             <Button type="button" variant="secondary">Close</Button>
           </DialogClose>

--- a/src/components/features/organizations/organization-logo-selector.tsx
+++ b/src/components/features/organizations/organization-logo-selector.tsx
@@ -125,7 +125,7 @@ export function OrganizationLogoSelector({ value, onChange }: OrganizationLogoSe
                     Emoji: ({ emoji, ...props }) => (
                       <button
                         type="button"
-                        className="flex size-8 items-center justify-center rounded-md text-lg hover:bg-accent data-[active]:bg-accent"
+                        className="flex size-8 items-center justify-center rounded-md text-lg hover:bg-accent data-active:bg-accent"
                         {...props}
                       >
                         {emoji.emoji}

--- a/src/components/features/reports/charts/AutomationExecutionsChart.tsx
+++ b/src/components/features/reports/charts/AutomationExecutionsChart.tsx
@@ -33,7 +33,7 @@ export function AutomationExecutionsChart({
 }: AutomationExecutionsChartProps) {
   return (
     <Card className={`flex flex-col h-full ${className}`}>
-      <CardHeader className="flex-shrink-0">
+      <CardHeader className="shrink-0">
         <CardTitle>Automation Executions</CardTitle>
         <CardDescription>{timeFilterDisplay}</CardDescription>
       </CardHeader>

--- a/src/components/features/reports/charts/AutomationSuccessRateChart.tsx
+++ b/src/components/features/reports/charts/AutomationSuccessRateChart.tsx
@@ -25,7 +25,7 @@ export function AutomationSuccessRateChart({
 }: AutomationSuccessRateChartProps) {
   return (
     <Card className={`flex flex-col h-full ${className}`}>
-      <CardHeader className="pb-0 flex-shrink-0">
+      <CardHeader className="pb-0 shrink-0">
         <CardTitle>Automation Success Rate</CardTitle>
         <CardDescription>{timeFilterDisplay}</CardDescription>
       </CardHeader>
@@ -105,7 +105,7 @@ export function AutomationSuccessRateChart({
           )}
         </div>
       </CardContent>
-      <CardFooter className="flex-col gap-2 text-sm flex-shrink-0">
+      <CardFooter className="flex-col gap-2 text-sm shrink-0">
         {automationStats && automationStats.total > 0 && (
           <>
             <div className="flex items-center gap-2 leading-none font-medium">

--- a/src/components/features/reports/charts/EventsByConnectorChart.tsx
+++ b/src/components/features/reports/charts/EventsByConnectorChart.tsx
@@ -46,7 +46,7 @@ export function EventsByConnectorChart({
 
   return (
     <Card className={`flex flex-col h-full ${className}`}>
-      <CardHeader className="flex flex-col items-stretch border-b flex-shrink-0 sm:flex-row">
+      <CardHeader className="flex flex-col items-stretch border-b shrink-0 sm:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 pb-3 sm:pb-0">
           <CardTitle>Events by Connector Type</CardTitle>
           <CardDescription>{timeFilterDisplay}</CardDescription>
@@ -71,7 +71,7 @@ export function EventsByConnectorChart({
               onClick={() => setActiveChart(category)}
             >
               <div className="flex items-center gap-2 min-w-0">
-                <ConnectorIcon connectorCategory={category} size={12} className="flex-shrink-0" />
+                <ConnectorIcon connectorCategory={category} size={12} className="shrink-0" />
                 <span className="text-muted-foreground text-xs truncate">
                   {chartConfig[category]?.label}
                 </span>

--- a/src/components/features/settings/services/SunTimesUpdateTrigger.tsx
+++ b/src/components/features/settings/services/SunTimesUpdateTrigger.tsx
@@ -106,9 +106,9 @@ export function SunTimesUpdateTrigger() {
           }`}>
             <div className="flex items-start gap-3">
               {lastResult.success ? (
-                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
               ) : (
-                <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
               )}
               
               <div className="flex-1 space-y-2">

--- a/src/components/features/settings/services/event-retention-settings.tsx
+++ b/src/components/features/settings/services/event-retention-settings.tsx
@@ -324,13 +324,13 @@ export function EventRetentionSettings({
                     handlePolicyChange({ strategy: value })
                   }
                 >
-                  <SelectTrigger className="w-full [&>span]:![display:inline] [&>span]:![-webkit-line-clamp:unset] [&>span]:!overflow-visible">
+                  <SelectTrigger className="w-full [&>span]:inline! [&>span]:[-webkit-line-clamp:unset]! [&>span]:overflow-visible!">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={RetentionStrategy.TIME}>
                       <div className="flex items-center justify-between w-full">
-                        <div className="flex items-center gap-2 flex-shrink-0">
+                        <div className="flex items-center gap-2 shrink-0">
                           <Clock className="h-4 w-4" />
                           <span className="whitespace-nowrap">Time-based</span>
                         </div>
@@ -339,7 +339,7 @@ export function EventRetentionSettings({
                     </SelectItem>
                     <SelectItem value={RetentionStrategy.COUNT}>
                       <div className="flex items-center justify-between w-full">
-                        <div className="flex items-center gap-2 flex-shrink-0">
+                        <div className="flex items-center gap-2 shrink-0">
                           <Database className="h-4 w-4" />
                           <span className="whitespace-nowrap">Count-based</span>
                         </div>
@@ -348,7 +348,7 @@ export function EventRetentionSettings({
                     </SelectItem>
                     <SelectItem value={RetentionStrategy.HYBRID}>
                       <div className="flex items-center justify-between w-full">
-                        <div className="flex items-center gap-2 flex-shrink-0">
+                        <div className="flex items-center gap-2 shrink-0">
                           <Blend className="h-4 w-4" />
                           <span className="whitespace-nowrap">Hybrid</span>
                         </div>

--- a/src/components/features/settings/services/linear/linear-config-form.tsx
+++ b/src/components/features/settings/services/linear/linear-config-form.tsx
@@ -186,7 +186,7 @@ export function LinearConfigForm({ initialConfig, isEnabled, onSaveSuccess }: Li
           >
             <SelectTrigger>
               {isLoadingTeams && (
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground mr-2 flex-shrink-0" />
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground mr-2 shrink-0" />
               )}
               <SelectValue placeholder={
                 isLoadingTeams 

--- a/src/components/features/settings/services/openai/openai-test-modal.tsx
+++ b/src/components/features/settings/services/openai/openai-test-modal.tsx
@@ -83,7 +83,7 @@ export function OpenAITestModal({ isOpen, onOpenChange, openAIConfig }: OpenAITe
           {/* Warning when not configured - matches OpenWeather pattern */}
           {(!openAIConfig || !openAIConfig.apiKey) && (
             <div className="p-3 rounded-md bg-yellow-50 border border-yellow-200 text-yellow-700 dark:bg-yellow-900/30 dark:border-yellow-700/50 dark:text-yellow-300 flex items-start">
-              <AlertCircle className="h-5 w-5 mr-2 flex-shrink-0" />
+              <AlertCircle className="h-5 w-5 mr-2 shrink-0" />
               <p className="text-sm">
                 {!openAIConfig 
                   ? 'OpenAI service is not configured. Please configure it in the settings before testing.'
@@ -127,9 +127,9 @@ export function OpenAITestModal({ isOpen, onOpenChange, openAIConfig }: OpenAITe
             }`}>
               <div className="flex items-start">
                 {testResult.success ? (
-                  <CheckCircle2 className="h-5 w-5 mr-2 flex-shrink-0" />
+                  <CheckCircle2 className="h-5 w-5 mr-2 shrink-0" />
                 ) : (
-                  <AlertCircle className="h-5 w-5 mr-2 flex-shrink-0" />
+                  <AlertCircle className="h-5 w-5 mr-2 shrink-0" />
                 )}
                 <div className="space-y-1">
                   <p className="text-sm font-medium">

--- a/src/components/features/settings/services/openweather/openweather-test-modal.tsx
+++ b/src/components/features/settings/services/openweather/openweather-test-modal.tsx
@@ -142,7 +142,7 @@ export function OpenWeatherTestModal({ isOpen, onOpenChange, openWeatherConfig }
 
         {!openWeatherConfig?.apiKey && (
           <div className="p-3 rounded-md bg-yellow-50 border border-yellow-200 text-yellow-700 dark:bg-yellow-900/30 dark:border-yellow-700/50 dark:text-yellow-300 flex items-start">
-            <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0" />
+            <AlertTriangle className="h-5 w-5 mr-2 shrink-0" />
             <p className="text-sm">
               OpenWeather API Key is not configured. Please configure it in the settings before testing.
             </p>
@@ -204,7 +204,7 @@ export function OpenWeatherTestModal({ isOpen, onOpenChange, openWeatherConfig }
                   : 'bg-red-50 border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-700/50 dark:text-red-300'
               }`}>
                 <div className="flex items-start">
-                  <Sun className="h-5 w-5 mr-2 flex-shrink-0" />
+                  <Sun className="h-5 w-5 mr-2 shrink-0" />
                   <div className="space-y-1">
                     <p className="text-sm font-medium">{testResult.message}</p>
                     {testResult.result && (

--- a/src/components/features/settings/services/pushcut/pushcut-test-modal.tsx
+++ b/src/components/features/settings/services/pushcut/pushcut-test-modal.tsx
@@ -242,7 +242,7 @@ export function PushcutTestModal({ isOpen, onOpenChange, pushcutConfig }: Pushcu
         {!pushcutConfig?.apiKey && (
           <div className="px-6 pb-6">
             <div className="p-3 rounded-md bg-yellow-50 border border-yellow-200 text-yellow-700 dark:bg-yellow-900/30 dark:border-yellow-700/50 dark:text-yellow-300 flex items-start">
-              <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0" />
+              <AlertTriangle className="h-5 w-5 mr-2 shrink-0" />
               <p className="text-sm">
                 Pushcut API Key is not configured. Please configure it in the settings before sending a test.
               </p>
@@ -250,7 +250,7 @@ export function PushcutTestModal({ isOpen, onOpenChange, pushcutConfig }: Pushcu
           </div>
         )}
 
-        <div className="flex-grow overflow-y-auto px-6 pb-6">
+        <div className="grow overflow-y-auto px-6 pb-6">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6" id="pushcut-test-form">
               <FormField

--- a/src/components/features/settings/services/pushover/pushover-test-modal.tsx
+++ b/src/components/features/settings/services/pushover/pushover-test-modal.tsx
@@ -277,7 +277,7 @@ export function PushoverTestModal({ isOpen, onOpenChange, pushoverConfig }: Push
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-grow overflow-y-auto px-6 pb-6">
+        <div className="grow overflow-y-auto px-6 pb-6">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6" id="pushover-test-form">
               <div className="space-y-4">

--- a/src/components/features/settings/services/system-settings-content.tsx
+++ b/src/components/features/settings/services/system-settings-content.tsx
@@ -171,7 +171,7 @@ export function SystemSettingsContent({
                 onClick={() => setActiveTab(tab.id)}
                 className={buttonClasses}
               >
-                <Icon className="mr-2 h-4 w-4 flex-shrink-0" />
+                <Icon className="mr-2 h-4 w-4 shrink-0" />
                 <span className="truncate">{tab.label}</span>
               </button>
             );

--- a/src/components/kanban.tsx
+++ b/src/components/kanban.tsx
@@ -425,7 +425,7 @@ export function KanbanBoard({
   return (
     <div
       className={cn(
-        'flex h-full flex-grow items-start gap-x-2 overflow-x-auto py-1',
+        'flex h-full grow items-start gap-x-2 overflow-x-auto py-1',
         className,
       )}
       ref={ref}
@@ -445,7 +445,7 @@ export function KanbanBoardExtraMargin({
 }: ComponentProps<'div'>) {
   return (
     <div
-      className={cn('h-1 w-8 flex-shrink-0', className)}
+      className={cn('h-1 w-8 shrink-0', className)}
       ref={ref}
       {...props}
     />
@@ -462,7 +462,7 @@ export type KanbanBoardColumnProps = {
 };
 
 export const kanbanBoardColumnClassNames =
-  'w-64 flex-shrink-0 rounded-lg border flex flex-col border-border bg-sidebar py-2 max-h-full';
+  'w-64 shrink-0 rounded-lg border flex flex-col border-border bg-sidebar py-2 max-h-full';
 
 export function KanbanBoardColumn({
   className,
@@ -595,7 +595,7 @@ export function KanbanBoardColumnList({
 }: ComponentProps<'ul'>) {
   return (
     <ul
-      className={cn('min-h-0.5 flex-grow overflow-y-auto', className)}
+      className={cn('min-h-0.5 grow overflow-y-auto', className)}
       ref={ref}
       {...props}
     />

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -160,7 +160,7 @@ export function AppSidebar() {
         </Link>
       </SidebarHeader>
       
-      <SidebarContent className="flex-grow">
+      <SidebarContent className="grow">
         {/* Organization Switcher */}
         <div className="p-2 border-b">
           <OrganizationSwitcher />
@@ -206,7 +206,7 @@ export function AppSidebar() {
                               }}
                               className="flex items-center w-full"
                             >
-                              <Icon className="mr-2 h-5 w-5 flex-shrink-0 group-data-[collapsible=icon]:mr-0" />
+                              <Icon className="mr-2 h-5 w-5 shrink-0 group-data-[collapsible=icon]:mr-0" />
                               <span className="truncate group-data-[collapsible=icon]:hidden">{item.label}</span>
                               {(() => {
                                 const dynamicBadge = getDynamicBadge(item, activeAlarmCount);
@@ -256,7 +256,7 @@ export function AppSidebar() {
               <div className={cn("flex h-full w-full items-center gap-2")}>
                 {/* Avatar: Always render, conditionally populate */}
                 <Avatar className={cn(
-                  "size-7 flex-shrink-0",
+                  "size-7 shrink-0",
                   "group-data-[collapsible=icon]:size-8",
                   // Muted background if loading or no user
                   (isPending || !currentUser) && "bg-muted"
@@ -306,7 +306,7 @@ export function AppSidebar() {
               side={isMobile ? 'bottom' : 'right'}
               align="end"
               sideOffset={4}
-              className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+              className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
             >
               <DropdownMenuLabel className="font-normal">
                  <div className="flex items-center gap-3">

--- a/src/components/layout/organization-switcher.tsx
+++ b/src/components/layout/organization-switcher.tsx
@@ -171,7 +171,7 @@ export function OrganizationSwitcher() {
               </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
-              className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+              className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
               align="start"
               side={isMobile ? 'bottom' : 'right'}
               sideOffset={4}

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -11,10 +11,10 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, icon, actions }: PageHeaderProps) {
   return (
-    <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4 flex-shrink-0">
+    <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4 shrink-0">
       {/* Title, Description, and Icon Section */}
-      <div className="flex items-center gap-3 flex-shrink-0 mr-4"> {/* Add margin-right for spacing on larger screens */}
-        {icon && <div className="text-muted-foreground flex-shrink-0">{icon}</div>}
+      <div className="flex items-center gap-3 shrink-0 mr-4"> {/* Add margin-right for spacing on larger screens */}
+        {icon && <div className="text-muted-foreground shrink-0">{icon}</div>}
         <div>
           <h1 className="text-xl font-semibold text-foreground">
             {title}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -177,7 +177,7 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
           className
         )}
       >
@@ -206,7 +206,7 @@ const ChartTooltipContent = React.forwardRef<
                       !hideIndicator && (
                         <div
                           className={cn(
-                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
                             {
                               "h-2.5 w-2.5": indicator === "dot",
                               "w-1": indicator === "line",

--- a/src/components/ui/chat/action-button.tsx
+++ b/src/components/ui/chat/action-button.tsx
@@ -99,7 +99,7 @@ export function ActionButton({
             "transition-all duration-200 flex items-center gap-2",
             // Let flexbox handle sizing naturally within flex-wrap container
             // Ensure text can truncate but maintain minimum usable width
-            "flex-shrink min-w-0 max-w-full",
+            "shrink min-w-0 max-w-full",
             isExecuting && "cursor-not-allowed",
             className
           )}
@@ -111,7 +111,7 @@ export function ActionButton({
             </>
           ) : (
             <>
-              <IconComponent className="h-4 w-4 flex-shrink-0" />
+              <IconComponent className="h-4 w-4 shrink-0" />
               <span className="text-xs font-medium truncate min-w-0">{action.label}</span>
             </>
           )}

--- a/src/components/ui/chat/chat.tsx
+++ b/src/components/ui/chat/chat.tsx
@@ -259,12 +259,12 @@ export function ChatMessages({
       onScroll={handleScroll}
       onTouchStart={handleTouchStart}
     >
-      <div className="max-w-full [grid-column:1/1] [grid-row:1/1]">
+      <div className="max-w-full col-[1/1] row-[1/1]">
         {children}
       </div>
 
       {!shouldAutoScroll && (
-        <div className="pointer-events-none flex flex-1 items-end justify-end [grid-column:1/1] [grid-row:1/1]">
+        <div className="pointer-events-none flex flex-1 items-end justify-end col-[1/1] row-[1/1]">
           <div className="sticky bottom-0 left-0 flex w-full justify-end">
             <Button
               onClick={scrollToBottom}

--- a/src/components/ui/chat/message-input.tsx
+++ b/src/components/ui/chat/message-input.tsx
@@ -435,7 +435,7 @@ function RecordingControls({
   if (isRecording) {
     return (
       <div
-        className="absolute inset-[1px] z-50 overflow-hidden rounded-xl"
+        className="absolute inset-px z-50 overflow-hidden rounded-xl"
         style={{ height: textAreaHeight - 2 }}
       >
         <AudioVisualizer
@@ -450,7 +450,7 @@ function RecordingControls({
   if (isTranscribing) {
     return (
       <div
-        className="absolute inset-[1px] z-50 overflow-hidden rounded-xl"
+        className="absolute inset-px z-50 overflow-hidden rounded-xl"
         style={{ height: textAreaHeight - 2 }}
       >
         <TranscribingOverlay />

--- a/src/components/ui/chat/prompt-suggestions.tsx
+++ b/src/components/ui/chat/prompt-suggestions.tsx
@@ -31,7 +31,7 @@ export function PromptSuggestions({
               onClick={() => append({ role: "user", content: text })}
               className="h-max rounded-lg border bg-background p-3 hover:bg-muted text-left flex items-start gap-3"
             >
-              {Icon && <Icon className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />}
+              {Icon && <Icon className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />}
               <p className="line-clamp-2 flex-1">{text}</p>
             </button>
           )

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
       className
     )}
     {...props}
@@ -63,8 +63,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
         className
       )}
       {...props}
@@ -82,7 +82,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -98,7 +98,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     checked={checked}
@@ -122,7 +122,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -11,7 +11,7 @@ const InputOTP = React.forwardRef<
   <OTPInput
     ref={ref}
     containerClassName={cn(
-      "flex items-center gap-2 has-[:disabled]:opacity-50",
+      "flex items-center gap-2 has-disabled:opacity-50",
       containerClassName
     )}
     className={cn("disabled:cursor-not-allowed", className)}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
         className
       )}
       {...props}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -31,9 +31,9 @@ const ScrollBar = React.forwardRef<
     className={cn(
       "flex touch-none select-none transition-colors",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "h-full w-2.5 border-l border-l-transparent p-px",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+        "h-2.5 flex-col border-t border-t-transparent p-px",
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -86,7 +86,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)"
         )}
       >
         {children}
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -17,7 +17,7 @@ const Separator = React.forwardRef<
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border",
-        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className
       )}
       {...props}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -145,7 +145,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
               className
             )}
             ref={ref}
@@ -185,7 +185,7 @@ const Sidebar = React.forwardRef<
       return (
         <div
           className={cn(
-            "flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground",
+            "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
             className
           )}
           ref={ref}
@@ -202,7 +202,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -232,24 +232,24 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "relative w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear",
+            "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
-              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
-              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+              : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
           )}
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
-              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
-              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+              : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className
           )}
           {...props}
@@ -309,7 +309,7 @@ const SidebarRail = React.forwardRef<
       title="Toggle Sidebar"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
@@ -520,7 +520,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem"
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -531,7 +531,7 @@ const sidebarMenuButtonVariants = cva(
       size: {
         default: "h-8 text-sm",
         sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
       },
     },
     defaultVariants: {
@@ -677,7 +677,7 @@ const SidebarMenuSkeleton = React.forwardRef<
         />
       )}
       <Skeleton
-        className="h-4 max-w-[--skeleton-width] flex-1"
+        className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-black px-3 py-1.5 text-xs text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-50 overflow-hidden rounded-md bg-black px-3 py-1.5 text-xs text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
         className
       )}
       {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,11 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
+
+@config "../../tailwind.config.js";
+
+@utility container {
+  margin-inline: auto;
+  padding-inline: 2rem;
+}
 
 @layer base {
   /* Light theme variables */
@@ -518,6 +523,7 @@
 } 
 
 @layer components {
+
   /* Table container utility class - wrap tables with this for proper scrolling */
   .table-container {
     @apply w-full overflow-auto rounded-md;
@@ -548,7 +554,7 @@
 
   /* AI Assistant Gradient Classes */
   .ai-gradient {
-    @apply bg-gradient-to-br from-blue-600 to-purple-600 text-white;
+    @apply bg-linear-to-br from-blue-600 to-purple-600 text-white;
   }
 
   .ai-gradient-hover {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -520,6 +520,10 @@
     overflow-x: hidden;
     max-width: 100vw;
   }
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
 } 
 
 @layer components {


### PR DESCRIPTION
This pull request primarily updates the Tailwind CSS and PostCSS integration and standardizes the use of modern Flexbox utility classes in the codebase. The most significant changes include upgrading Tailwind CSS to v4, replacing `autoprefixer` and the default Tailwind PostCSS plugin with `@tailwindcss/postcss`, and refactoring numerous UI components to use the newer `shrink-0` and `grow` utility classes instead of the deprecated `flex-shrink-0` and `flex-grow`.

**Build tooling and dependency updates:**

* Upgraded `tailwindcss` to version 4.1.11 and added `@tailwindcss/postcss` as a dependency, while removing `autoprefixer` from the dependencies in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R130) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L140) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L152-R152)
* Updated `postcss.config.mjs` to use `@tailwindcss/postcss` instead of the previous `tailwindcss` and `autoprefixer` plugins.

**UI and Flexbox utility class refactors:**

* Replaced all instances of `flex-shrink-0` with `shrink-0` and `flex-grow` with `grow` across multiple component files to align with Tailwind CSS v4 conventions. This affects files such as `src/app/(features)/alarm-zones/page.tsx`, `src/app/(features)/automations/page.tsx`, `src/app/(features)/devices/page.tsx`, `src/app/(features)/events/page.tsx`, `src/app/(features)/locations/page.tsx`, `src/app/(features)/system-logs/page.tsx`, and `src/app/page.tsx`. [[1]](diffhunk://#diff-1faf5fc9826daa8c74ef75ced551563205db0b3009c6d778bba4ec8476922037L339-R339) [[2]](diffhunk://#diff-1faf5fc9826daa8c74ef75ced551563205db0b3009c6d778bba4ec8476922037L426-R426) [[3]](diffhunk://#diff-1faf5fc9826daa8c74ef75ced551563205db0b3009c6d778bba4ec8476922037L482-R482) [[4]](diffhunk://#diff-1faf5fc9826daa8c74ef75ced551563205db0b3009c6d778bba4ec8476922037L529-R529) [[5]](diffhunk://#diff-98a07a7247decb9e3615ff337fa9e26f7f75ff012e16b4fafe3ed4af00d6763dL73-R76) [[6]](diffhunk://#diff-98c7b07ef927eb81614418719c6b5f8652d5dc85d36bfb2bb416754cf28d3aebL522-R522) [[7]](diffhunk://#diff-98c7b07ef927eb81614418719c6b5f8652d5dc85d36bfb2bb416754cf28d3aebL718-R718) [[8]](diffhunk://#diff-98c7b07ef927eb81614418719c6b5f8652d5dc85d36bfb2bb416754cf28d3aebL740-R741) [[9]](diffhunk://#diff-98c7b07ef927eb81614418719c6b5f8652d5dc85d36bfb2bb416754cf28d3aebL807-R807) [[10]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L782-R782) [[11]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L870-R870) [[12]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L1071-R1071) [[13]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L1085-R1085) [[14]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L1372-R1382) [[15]](diffhunk://#diff-a3aa4bc0f78b3cb3da1f213ac732f4b3a83de33dd8cdaa4292c99505c20f9d33L1400-R1400) [[16]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L423-R423) [[17]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L517-R517) [[18]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L573-R573) [[19]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L594-R594) [[20]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L647-R651) [[21]](diffhunk://#diff-ca3a3497b06f2e4bbc2f4c2b1e110ad29358fd7e1cda529a8fd072db59ecbe32L671-R673) [[22]](diffhunk://#diff-0daee9651ea7ff19c06171af4a5ed89efa1970a137a2a39be7460611fe0381dbL181-R181) [[23]](diffhunk://#diff-0daee9651ea7ff19c06171af4a5ed89efa1970a137a2a39be7460611fe0381dbL206-R206) [[24]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL157-R157)

These updates ensure compatibility with the latest Tailwind CSS version and improve code consistency across the UI.