### PR TITLE
Add user layout preferences and default layout support

### DIFF
--- a/src/app/(features)/play/page.tsx
+++ b/src/app/(features)/play/page.tsx
@@ -1,337 +1,389 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
-import { useFusionStore } from '@/stores/store';
-import { DeviceType } from '@/lib/mappings/definitions';
-import type { DeviceWithConnector } from '@/types';
-import { PageHeader } from '@/components/layout/page-header';
-import { MonitorPlay } from 'lucide-react';
-import { LocationSpaceSelector } from '@/components/common/LocationSpaceSelector';
-import { PlayGrid } from '@/components/features/play/play-grid';
-import type { Layout } from 'react-grid-layout';
-import { PlayLayoutControls } from '@/components/features/play/PlayLayoutControls';
-import type { PlayLayout, PlayGridLayoutItem } from '@/types/play';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { formatConnectorCategory } from '@/lib/utils';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { EditCamerasDialog } from '@/components/features/play/EditCamerasDialog';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { toast } from 'sonner';
+import React, { useEffect, useMemo, useState } from "react";
+import { useFusionStore } from "@/stores/store";
+import { DeviceType } from "@/lib/mappings/definitions";
+import type { DeviceWithConnector } from "@/types";
+import { PageHeader } from "@/components/layout/page-header";
+import { MonitorPlay } from "lucide-react";
+import { LocationSpaceSelector } from "@/components/common/LocationSpaceSelector";
+import { PlayGrid } from "@/components/features/play/play-grid";
+import type { Layout } from "react-grid-layout";
+import { PlayLayoutControls } from "@/components/features/play/PlayLayoutControls";
+import type { PlayLayout, PlayGridLayoutItem } from "@/types/play";
+import { Input } from "@/components/ui/input";
+import { EditCamerasDialog } from "@/components/features/play/EditCamerasDialog";
+import { toast } from "sonner";
 
 export default function PlayPage() {
-	const allDevices = useFusionStore(state => state.allDevices);
-	const isLoadingAllDevices = useFusionStore(state => state.isLoadingAllDevices);
-	const allDevicesHasInitiallyLoaded = useFusionStore(state => state.allDevicesHasInitiallyLoaded);
-	const fetchAllDevices = useFusionStore(state => state.fetchAllDevices);
-	const locations = useFusionStore(state => state.locations);
-	const spaces = useFusionStore(state => state.spaces);
+  const allDevices = useFusionStore((state) => state.allDevices);
+  const isLoadingAllDevices = useFusionStore(
+    (state) => state.isLoadingAllDevices
+  );
+  const allDevicesHasInitiallyLoaded = useFusionStore(
+    (state) => state.allDevicesHasInitiallyLoaded
+  );
+  const fetchAllDevices = useFusionStore((state) => state.fetchAllDevices);
+  const locations = useFusionStore((state) => state.locations);
+  const spaces = useFusionStore((state) => state.spaces);
 
-	const [locationFilter, setLocationFilter] = useState<string>('all');
-	const [spaceFilter, setSpaceFilter] = useState<string>('all');
-	const [searchTerm, setSearchTerm] = useState('');
-  
+  const [locationFilter, setLocationFilter] = useState<string>("all");
+  const [spaceFilter, setSpaceFilter] = useState<string>("all");
+  const [searchTerm, setSearchTerm] = useState("");
 
-	const [layouts, setLayouts] = useState<PlayLayout[]>([]);
-	const [activeLayoutId, setActiveLayoutId] = useState<string | 'auto'>('auto');
-	const [latestGridLayout, setLatestGridLayout] = useState<Layout[] | null>(null);
-	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-	const [editSelectedIds, setEditSelectedIds] = useState<Set<string>>(new Set());
-	const [editSearch, setEditSearch] = useState('');
-  const [connectorFilter, setConnectorFilter] = useState<string>('all');
-  const [prefs, setPrefs] = useState<{ defaultLayoutId: string | null }>({ defaultLayoutId: null });
+  const [layouts, setLayouts] = useState<PlayLayout[]>([]);
+  const [activeLayoutId, setActiveLayoutId] = useState<string | "auto">("auto");
+  const [latestGridLayout, setLatestGridLayout] = useState<Layout[] | null>(
+    null
+  );
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [editSelectedIds, setEditSelectedIds] = useState<Set<string>>(
+    new Set()
+  );
+  const [editSearch, setEditSearch] = useState("");
+  const [prefs, setPrefs] = useState<{ defaultLayoutId: string | null }>({
+    defaultLayoutId: null,
+  });
 
-	useEffect(() => { document.title = 'Play // Fusion'; }, []);
-	useEffect(() => {
-		if (!allDevicesHasInitiallyLoaded && !isLoadingAllDevices) {
-			fetchAllDevices();
-		}
-	}, [allDevicesHasInitiallyLoaded, isLoadingAllDevices, fetchAllDevices]);
+  useEffect(() => {
+    document.title = "Play // Fusion";
+  }, []);
+  useEffect(() => {
+    if (!allDevicesHasInitiallyLoaded && !isLoadingAllDevices) {
+      fetchAllDevices();
+    }
+  }, [allDevicesHasInitiallyLoaded, isLoadingAllDevices, fetchAllDevices]);
 
   // Load layouts and preferences on mount
   useEffect(() => {
     (async () => {
       try {
         const [layoutsRes, prefsRes] = await Promise.all([
-          fetch('/api/play/layouts'),
-          fetch('/api/play/preferences'),
+          fetch("/api/play/layouts"),
+          fetch("/api/play/preferences"),
         ]);
-        const [layoutsJson, prefsJson] = await Promise.all([layoutsRes.json(), prefsRes.json()]);
+        const [layoutsJson, prefsJson] = await Promise.all([
+          layoutsRes.json(),
+          prefsRes.json(),
+        ]);
         if (!layoutsRes.ok || !layoutsJson.success) {
-          toast.error('Failed to load layouts', { description: layoutsJson?.error || 'Please try again.' });
+          toast.error("Failed to load layouts", {
+            description: layoutsJson?.error || "Please try again.",
+          });
           return;
         }
         setLayouts(layoutsJson.data);
         if (prefsRes.ok && prefsJson?.success) {
           setPrefs({ defaultLayoutId: prefsJson.data.defaultLayoutId ?? null });
-          if (prefsJson.data.defaultLayoutId && layoutsJson.data.some((l: PlayLayout) => l.id === prefsJson.data.defaultLayoutId)) {
+          if (
+            prefsJson.data.defaultLayoutId &&
+            layoutsJson.data.some(
+              (l: PlayLayout) => l.id === prefsJson.data.defaultLayoutId
+            )
+          ) {
             setActiveLayoutId(prefsJson.data.defaultLayoutId);
           }
         }
       } catch (e) {
-        console.error('fetch layouts/prefs', e);
-        toast.error('Failed to load layouts');
+        console.error("fetch layouts/prefs", e);
+        toast.error("Failed to load layouts");
       }
     })();
   }, []);
 
-	const cameraDevices = useMemo<DeviceWithConnector[]>(() => {
-		let list = allDevices.filter(d =>
-			d.connectorCategory === 'piko' &&
-			d.deviceTypeInfo?.type === DeviceType.Camera &&
-			d.deviceId && d.connectorId
-		);
+  const cameraDevices = useMemo<DeviceWithConnector[]>(() => {
+    let list = allDevices.filter(
+      (d) =>
+        d.connectorCategory === "piko" &&
+        d.deviceTypeInfo?.type === DeviceType.Camera &&
+        d.deviceId &&
+        d.connectorId
+    );
 
-		if (spaceFilter !== 'all') {
-			list = list.filter(d => d.spaceId === spaceFilter);
-		} else if (locationFilter !== 'all') {
-			const ids = spaces.filter(s => s.locationId === locationFilter).map(s => s.id);
-			list = list.filter(d => d.spaceId && ids.includes(d.spaceId));
-		}
+    if (spaceFilter !== "all") {
+      list = list.filter((d) => d.spaceId === spaceFilter);
+    } else if (locationFilter !== "all") {
+      const ids = spaces
+        .filter((s) => s.locationId === locationFilter)
+        .map((s) => s.id);
+      list = list.filter((d) => d.spaceId && ids.includes(d.spaceId));
+    }
 
-		if (searchTerm.trim()) {
-			const term = searchTerm.toLowerCase();
-			list = list.filter(d => d.name?.toLowerCase().includes(term));
-		}
+    if (searchTerm.trim()) {
+      const term = searchTerm.toLowerCase();
+      list = list.filter((d) => d.name?.toLowerCase().includes(term));
+    }
 
-		return list;
-	}, [allDevices, locationFilter, spaceFilter, spaces, searchTerm]);
+    return list;
+  }, [allDevices, locationFilter, spaceFilter, spaces, searchTerm]);
 
-	// Determine active layout
-	const activeLayout = activeLayoutId === 'auto' ? null : layouts.find(l => l.id === activeLayoutId) || null;
+  // Determine active layout
+  const activeLayout =
+    activeLayoutId === "auto"
+      ? null
+      : layouts.find((l) => l.id === activeLayoutId) || null;
 
   const viewDevices = useMemo<DeviceWithConnector[]>(() => {
     if (!activeLayout) return cameraDevices;
     const activeAllowed = new Set(activeLayout.deviceIds);
-    const fromGrid = latestGridLayout ? new Set(latestGridLayout.map(it => it.i)) : null;
+    const fromGrid = latestGridLayout
+      ? new Set(latestGridLayout.map((it) => it.i))
+      : null;
     const allowedIds = fromGrid
-      ? new Set(Array.from(activeAllowed).filter(id => fromGrid.has(id)))
+      ? new Set(Array.from(activeAllowed).filter((id) => fromGrid.has(id)))
       : activeAllowed;
-    return cameraDevices.filter(d => allowedIds.has(d.id));
+    return cameraDevices.filter((d) => allowedIds.has(d.id));
   }, [cameraDevices, activeLayout, latestGridLayout]);
 
-
-	// Dirty detection: compare latest grid to the active layout items
+  // Dirty detection: compare latest grid to the active layout items
   const isDirty = useMemo(() => {
     if (!activeLayout || !latestGridLayout) return false;
     const activeAllowed = new Set(activeLayout.deviceIds);
-    const filtered = latestGridLayout.filter(it => activeAllowed.has(it.i));
+    const filtered = latestGridLayout.filter((it) => activeAllowed.has(it.i));
     if (activeLayout.items.length !== filtered.length) return true;
-    const byId = new Map(activeLayout.items.map(it => [it.i, it]));
+    const byId = new Map(activeLayout.items.map((it) => [it.i, it]));
     for (const cur of filtered) {
       const prev = byId.get(cur.i);
       if (!prev) return true;
-      if (prev.x !== cur.x || prev.y !== cur.y || prev.w !== cur.w || prev.h !== cur.h) return true;
+      if (
+        prev.x !== cur.x ||
+        prev.y !== cur.y ||
+        prev.w !== cur.w ||
+        prev.h !== cur.h
+      )
+        return true;
     }
     return false;
   }, [activeLayout, latestGridLayout]);
 
-	const handleCreate = async (name: string) => {
-		try {
-			const res = await fetch('/api/play/layouts', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name, deviceIds: [], items: [] }) });
-			const json = await res.json();
-			if (!res.ok || !json.success) throw new Error(json.error || 'Failed');
-			setLayouts(prev => [...prev, json.data]);
-			setActiveLayoutId(json.data.id);
-      toast.success('Layout created');
-		} catch (e) { console.error('create layout', e); }
-	};
-	const handleRename = async (id: string, name: string) => {
-		try {
-			const res = await fetch(`/api/play/layouts/${id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name }) });
-			const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.error || 'Failed');
-			setLayouts(prev => prev.map(l => l.id === id ? { ...l, name } : l));
-      toast.success('Layout renamed');
-		} catch (e) { console.error('rename layout', e); }
-	};
-	const handleDelete = async (id: string) => {
-		try {
-			await fetch(`/api/play/layouts/${id}`, { method: 'DELETE' });
-			setLayouts(prev => prev.filter(l => l.id !== id));
-			if (activeLayoutId === id) setActiveLayoutId('auto');
-      setPrefs(prev => ({
-        defaultLayoutId: prev.defaultLayoutId === id ? null : prev.defaultLayoutId,
+  const handleCreate = async (name: string) => {
+    try {
+      const res = await fetch("/api/play/layouts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, deviceIds: [], items: [] }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || "Failed");
+      setLayouts((prev) => [...prev, json.data]);
+      setActiveLayoutId(json.data.id);
+      toast.success("Layout created");
+    } catch (e) {
+      console.error("create layout", e);
+    }
+  };
+  const handleRename = async (id: string, name: string) => {
+    try {
+      const res = await fetch(`/api/play/layouts/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || "Failed");
+      setLayouts((prev) => prev.map((l) => (l.id === id ? { ...l, name } : l)));
+      toast.success("Layout renamed");
+    } catch (e) {
+      console.error("rename layout", e);
+    }
+  };
+  const handleDelete = async (id: string) => {
+    try {
+      await fetch(`/api/play/layouts/${id}`, { method: "DELETE" });
+      setLayouts((prev) => prev.filter((l) => l.id !== id));
+      if (activeLayoutId === id) setActiveLayoutId("auto");
+      setPrefs((prev) => ({
+        defaultLayoutId:
+          prev.defaultLayoutId === id ? null : prev.defaultLayoutId,
       }));
-      toast.success('Layout deleted');
-		} catch (e) { console.error('delete layout', e); }
-	};
+      toast.success("Layout deleted");
+    } catch (e) {
+      console.error("delete layout", e);
+    }
+  };
   const handleSave = async () => {
-    if (!activeLayoutId || activeLayoutId === 'auto' || !latestGridLayout || !activeLayout) return;
+    if (
+      !activeLayoutId ||
+      activeLayoutId === "auto" ||
+      !latestGridLayout ||
+      !activeLayout
+    )
+      return;
     try {
       const allowed = new Set(activeLayout.deviceIds);
-      const itemsToSave = latestGridLayout.filter(it => allowed.has(it.i));
-      const deviceIds = itemsToSave.map(it => it.i);
-      const itemsToPersist: PlayGridLayoutItem[] = itemsToSave.map(it => ({ i: it.i, x: it.x, y: it.y, w: it.w, h: it.h, static: it.static }));
+      const itemsToSave = latestGridLayout.filter((it) => allowed.has(it.i));
+      const deviceIds = itemsToSave.map((it) => it.i);
+      const itemsToPersist: PlayGridLayoutItem[] = itemsToSave.map((it) => ({
+        i: it.i,
+        x: it.x,
+        y: it.y,
+        w: it.w,
+        h: it.h,
+        static: it.static,
+      }));
       const res = await fetch(`/api/play/layouts/${activeLayoutId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ items: itemsToPersist, deviceIds }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err?.error || 'Failed to save layout');
+        throw new Error(err?.error || "Failed to save layout");
       }
-      setLayouts(prev => prev.map(l => l.id === activeLayoutId ? { ...l, items: itemsToPersist, deviceIds } : l));
-      toast.success('Layout saved');
-    } catch (e) { console.error('save layout items', e); }
+      setLayouts((prev) =>
+        prev.map((l) =>
+          l.id === activeLayoutId
+            ? { ...l, items: itemsToPersist, deviceIds }
+            : l
+        )
+      );
+      toast.success("Layout saved");
+    } catch (e) {
+      console.error("save layout items", e);
+    }
   };
 
   const handleRemoveFromLayout = (deviceId: string) => {
-    if (!activeLayoutId || activeLayoutId === 'auto') return;
-    const base: Layout[] = latestGridLayout ?? (activeLayout?.items as unknown as Layout[]) ?? [];
-    setLatestGridLayout(base.filter(it => it.i !== deviceId));
+    if (!activeLayoutId || activeLayoutId === "auto") return;
+    const base: Layout[] =
+      latestGridLayout ?? (activeLayout?.items as unknown as Layout[]) ?? [];
+    setLatestGridLayout(base.filter((it) => it.i !== deviceId));
   };
-	const handleReset = () => setActiveLayoutId('auto');
 
-	// Edit Cameras dialog data and handlers
-	const availableCameras = useMemo(() => cameraDevices, [cameraDevices]);
-	const uniqueConnectors = useMemo(() => {
-		const map = new Map<string, { name: string; category: string }>();
-		for (const cam of availableCameras) {
-			const name = cam.connectorName ?? formatConnectorCategory(cam.connectorCategory);
-			if (!map.has(name)) map.set(name, { name, category: cam.connectorCategory });
-		}
-		return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
-	}, [availableCameras]);
+  // Edit Cameras dialog data and handlers
+  const availableCameras = useMemo(() => cameraDevices, [cameraDevices]);
 
-	const filteredCameras = useMemo(() => {
-		const term = editSearch.trim().toLowerCase();
-		return availableCameras.filter(cam => {
-			const nameOk = !term || (cam.name || '').toLowerCase().includes(term);
-			const connName = cam.connectorName ?? formatConnectorCategory(cam.connectorCategory);
-			const connOk = connectorFilter === 'all' || connName === connectorFilter;
-			return nameOk && connOk;
-		});
-	}, [availableCameras, editSearch, connectorFilter]);
-
-	const [visibleAssignedCameras, visibleAvailableCameras] = useMemo(() => {
-		const assigned: DeviceWithConnector[] = [];
-		const available: DeviceWithConnector[] = [];
-		for (const cam of filteredCameras) {
-			if (editSelectedIds.has(cam.id)) assigned.push(cam); else available.push(cam);
-		}
-		return [assigned, available];
-	}, [filteredCameras, editSelectedIds]);
-
-	const applyEditCameras = async (selectedIdsParam: string[]) => {
-		if (!activeLayoutId || activeLayoutId === 'auto') return;
-		const layout = layouts.find(l => l.id === activeLayoutId);
-		if (!layout) return;
-		const nextIds = selectedIdsParam;
-		const keptItems = layout.items.filter(it => nextIds.includes(it.i));
-		const existingIds = new Set(keptItems.map(it => it.i));
-		const newMembers = nextIds.filter(id => !existingIds.has(id));
-		const tileSpan = 4;
-		const perRow = Math.max(1, Math.floor(12 / tileSpan));
-		const startIndex = keptItems.length;
+  const applyEditCameras = async (selectedIdsParam: string[]) => {
+    if (!activeLayoutId || activeLayoutId === "auto") return;
+    const layout = layouts.find((l) => l.id === activeLayoutId);
+    if (!layout) return;
+    const nextIds = selectedIdsParam;
+    const keptItems = layout.items.filter((it) => nextIds.includes(it.i));
+    const existingIds = new Set(keptItems.map((it) => it.i));
+    const newMembers = nextIds.filter((id) => !existingIds.has(id));
+    const tileSpan = 4;
+    const perRow = Math.max(1, Math.floor(12 / tileSpan));
+    const startIndex = keptItems.length;
     const newItems: PlayGridLayoutItem[] = newMembers.map((id, idx) => {
-			const row = Math.floor((startIndex + idx) / perRow);
-			const col = ((startIndex + idx) % perRow) * tileSpan;
+      const row = Math.floor((startIndex + idx) / perRow);
+      const col = ((startIndex + idx) % perRow) * tileSpan;
       return { i: id, x: col, y: row, w: tileSpan, h: 3, static: false };
-		});
-		const updated = { deviceIds: nextIds, items: [...keptItems, ...newItems] };
-		setLayouts(prev => prev.map(l => l.id === activeLayoutId ? { ...l, ...updated } : l));
-		setIsEditDialogOpen(false);
-		try {
-			await fetch(`/api/play/layouts/${activeLayoutId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(updated) });
-		} catch (e) { console.error('edit cameras apply', e); }
-	};
+    });
+    const updated = { deviceIds: nextIds, items: [...keptItems, ...newItems] };
+    setLayouts((prev) =>
+      prev.map((l) => (l.id === activeLayoutId ? { ...l, ...updated } : l))
+    );
+    setIsEditDialogOpen(false);
+    try {
+      await fetch(`/api/play/layouts/${activeLayoutId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updated),
+      });
+    } catch (e) {
+      console.error("edit cameras apply", e);
+    }
+  };
 
-
-	const actions = (
-		<div className="flex items-center gap-2 w-full flex-wrap">
-			<div className="flex flex-col gap-1">
-				<div className="flex items-center gap-2">
-			<LocationSpaceSelector
-				locationFilter={locationFilter}
-				spaceFilter={spaceFilter}
-				searchTerm={searchTerm}
-				locations={locations}
-				spaces={spaces}
-				onLocationChange={setLocationFilter}
-				onSpaceChange={setSpaceFilter}
-				onSearchChange={setSearchTerm}
-			/>
-			<div className="w-[220px]">
-				<Input
-					placeholder="Search cameras..."
-					value={searchTerm}
-					onChange={(e) => setSearchTerm(e.target.value)}
-					className="h-9"
-				/>
-			</div>
-            
-				</div>
-			</div>
-			<div className="ml-auto flex items-center gap-2">
-				<div className="h-8 w-px bg-border" aria-hidden="true" />
-          <PlayLayoutControls
-				layouts={layouts.map(l => ({ id: l.id, name: l.name }))}
-				activeLayoutId={activeLayoutId}
-				onSelect={setActiveLayoutId}
-				onCreate={handleCreate}
-				onRename={handleRename}
-				onDelete={handleDelete}
-				onSave={handleSave}
-				isDirty={isDirty}
-				onEditCameras={() => {
-					if (!activeLayout) return;
-					setEditSelectedIds(new Set(activeLayout.deviceIds));
-					setEditSearch('');
-					setIsEditDialogOpen(true);
-				}}
-						defaultLayoutId={prefs.defaultLayoutId}
-          onSetDefault={async (id) => {
-            const defaultLayoutId = id === 'auto' ? null : id;
-            setPrefs(prev => ({ ...prev, defaultLayoutId }));
-            if (id === 'auto') setActiveLayoutId('auto'); else setActiveLayoutId(id);
-            try {
-              await fetch('/api/play/preferences', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ defaultLayoutId }) });
-            } catch (e) { console.error('set default', e); }
+  const actions = (
+    <div className="flex items-center gap-2 w-full flex-wrap">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <LocationSpaceSelector
+            locationFilter={locationFilter}
+            spaceFilter={spaceFilter}
+            searchTerm={searchTerm}
+            locations={locations}
+            spaces={spaces}
+            onLocationChange={setLocationFilter}
+            onSpaceChange={setSpaceFilter}
+            onSearchChange={setSearchTerm}
+          />
+          <div className="w-[220px]">
+            <Input
+              placeholder="Search cameras..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="h-9"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <div className="h-8 w-px bg-border" aria-hidden="true" />
+        <PlayLayoutControls
+          layouts={layouts.map((l) => ({ id: l.id, name: l.name }))}
+          activeLayoutId={activeLayoutId}
+          onSelect={setActiveLayoutId}
+          onCreate={handleCreate}
+          onRename={handleRename}
+          onDelete={handleDelete}
+          onSave={handleSave}
+          isDirty={isDirty}
+          onEditCameras={() => {
+            if (!activeLayout) return;
+            setEditSelectedIds(new Set(activeLayout.deviceIds));
+            setEditSearch("");
+            setIsEditDialogOpen(true);
           }}
-				/>
-			</div>
-			<EditCamerasDialog
-				isOpen={isEditDialogOpen}
-				onOpenChange={setIsEditDialogOpen}
-				cameras={availableCameras}
-				initialSelectedIds={Array.from(editSelectedIds)}
-				onApply={(ids) => { applyEditCameras(ids); }}
-			/>
-		</div>
-	);
+          defaultLayoutId={prefs.defaultLayoutId}
+          onSetDefault={async (id) => {
+            const defaultLayoutId = id === "auto" ? null : id;
+            setPrefs((prev) => ({ ...prev, defaultLayoutId }));
+            if (id === "auto") setActiveLayoutId("auto");
+            else setActiveLayoutId(id);
+            try {
+              await fetch("/api/play/preferences", {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ defaultLayoutId }),
+              });
+            } catch (e) {
+              console.error("set default", e);
+              toast.error?.("Failed to set default layout. Please try again.");
+            }
+          }}
+        />
+      </div>
+      <EditCamerasDialog
+        isOpen={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        cameras={availableCameras}
+        initialSelectedIds={Array.from(editSelectedIds)}
+        onApply={(ids) => {
+          applyEditCameras(ids);
+        }}
+      />
+    </div>
+  );
 
-	return (
-		<div className="flex flex-col h-full p-4 md:p-6">
-			<PageHeader
-				title="Play"
-				icon={<MonitorPlay className="h-6 w-6" />}
-				actions={actions}
-			/>
-			<div>
-        {(isLoadingAllDevices || !allDevicesHasInitiallyLoaded) ? (
-          <div className="h-64 flex items-center justify-center text-muted-foreground">Loading…</div>
+  return (
+    <div className="flex flex-col h-full p-4 md:p-6">
+      <PageHeader
+        title="Play"
+        icon={<MonitorPlay className="h-6 w-6" />}
+        actions={actions}
+      />
+      <div>
+        {isLoadingAllDevices || !allDevicesHasInitiallyLoaded ? (
+          <div className="h-64 flex items-center justify-center text-muted-foreground">
+            Loading…
+          </div>
         ) : (
           <PlayGrid
             devices={viewDevices}
             onLayoutChange={setLatestGridLayout}
             initialLayoutItems={activeLayout?.items}
-            onRemoveFromLayout={activeLayoutId === 'auto' ? undefined : handleRemoveFromLayout}
+            onRemoveFromLayout={
+              activeLayoutId === "auto" ? undefined : handleRemoveFromLayout
+            }
             onAddCameras={() => setIsEditDialogOpen(true)}
             spaces={spaces}
             locations={locations}
-            key={`grid-${activeLayout?.id || 'auto'}`}
+            key={`grid-${activeLayout?.id || "auto"}`}
           />
         )}
-			</div>
-		</div>
-	);
+      </div>
+    </div>
+  );
 }
-
-

--- a/src/app/(features)/play/page.tsx
+++ b/src/app/(features)/play/page.tsx
@@ -340,7 +340,7 @@ export default function PlayPage() {
               });
             } catch (e) {
               console.error("set default", e);
-              toast.error?.("Failed to set default layout. Please try again.");
+              toast.error("Failed to set default layout. Please try again.");
             }
           }}
         />

--- a/src/app/api/play/preferences/route.ts
+++ b/src/app/api/play/preferences/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { withOrganizationAuth } from '@/lib/auth/withOrganizationAuth';
+import { and, eq } from 'drizzle-orm';
+import { db, userLayoutPreferences, layouts } from '@/data/db';
+
+type Prefs = { defaultLayoutId: string | null };
+
+export const GET = withOrganizationAuth(async (req: NextRequest, authCtx) => {
+  const userId = authCtx.userId;
+  const organizationId = authCtx.organizationId;
+
+  const rows = await db.select().from(userLayoutPreferences)
+    .where(and(
+      eq(userLayoutPreferences.userId, userId),
+      eq(userLayoutPreferences.organizationId, organizationId),
+    ))
+    .limit(1);
+
+  if (rows.length === 0) {
+    const data: Prefs = { defaultLayoutId: null };
+    return NextResponse.json({ success: true, data });
+  }
+
+  const row = rows[0];
+  const data: Prefs = { defaultLayoutId: row.defaultLayoutId ?? null };
+  return NextResponse.json({ success: true, data });
+});
+
+export const PATCH = withOrganizationAuth(async (req: NextRequest, authCtx) => {
+  const userId = authCtx.userId;
+  const organizationId = authCtx.organizationId;
+
+  let body: Partial<Prefs> = {};
+  try {
+    body = await req.json();
+  } catch {
+    // ignore
+  }
+
+  let nextDefault: string | null | undefined = body.defaultLayoutId;
+
+  // Normalize inputs
+  if (typeof nextDefault === 'string' && nextDefault.trim() === '') nextDefault = null;
+
+  // Validate layout ids belong to the same organization
+  if (typeof nextDefault === 'string') {
+    const valid = await db.select({ id: layouts.id }).from(layouts)
+      .where(and(eq(layouts.organizationId, organizationId), eq(layouts.id, nextDefault)))
+      .limit(1);
+    if (valid.length === 0) {
+      return NextResponse.json({ success: false, error: 'defaultLayoutId is invalid for this organization' }, { status: 400 });
+    }
+  }
+
+  // Read existing
+  const existing = await db.select().from(userLayoutPreferences)
+    .where(and(
+      eq(userLayoutPreferences.userId, userId),
+      eq(userLayoutPreferences.organizationId, organizationId),
+    ))
+    .limit(1);
+
+  const current: Prefs = existing.length > 0
+    ? { defaultLayoutId: existing[0].defaultLayoutId ?? null }
+    : { defaultLayoutId: null };
+
+  const updated: Prefs = {
+    defaultLayoutId: typeof nextDefault !== 'undefined' ? nextDefault : current.defaultLayoutId,
+  };
+
+  if (existing.length === 0) {
+    await db.insert(userLayoutPreferences).values({
+      userId,
+      organizationId,
+      defaultLayoutId: updated.defaultLayoutId,
+    });
+  } else {
+    await db.update(userLayoutPreferences)
+      .set({
+        defaultLayoutId: updated.defaultLayoutId,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(userLayoutPreferences.userId, userId),
+        eq(userLayoutPreferences.organizationId, organizationId),
+      ));
+  }
+
+  return NextResponse.json({ success: true, data: updated });
+});
+
+

--- a/src/components/features/account/users-table.tsx
+++ b/src/components/features/account/users-table.tsx
@@ -575,6 +575,7 @@ function EditUserDialog({ user, isOpen, onOpenChange }: EditUserDialogProps) {
         </DialogHeader>
         <form action={formAction} ref={formRef}>
           <input type="hidden" name="id" value={user.id} />
+          <input type="hidden" name="role" value={role} />
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="edit-name" className="text-right">

--- a/src/components/features/locations/spaces/space-camera-wall-dialog.tsx
+++ b/src/components/features/locations/spaces/space-camera-wall-dialog.tsx
@@ -119,7 +119,7 @@ const SpaceCameraGrid: React.FC<SpaceCameraGridProps> = ({ cameraDevices }) => {
          return (
            <div key={device.id} className="overflow-hidden grid-item-container">
              <Card className="h-full w-full flex flex-col">
-               <CardHeader className="p-1.5 shrink-0 border-b bg-muted/30 rounded-t-lg">
+               <CardHeader className="p-1.5 shrink-0 bg-black text-white rounded-t-lg">
                  <CardTitle 
                    className="text-xs font-medium truncate text-center" 
                    title={device.name}

--- a/src/components/features/play/PlayLayoutControls.tsx
+++ b/src/components/features/play/PlayLayoutControls.tsx
@@ -107,8 +107,8 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 						>
 						<Pin className="mr-2 h-4 w-4" />
 						Set as default
-						</DropdownMenuItem>
-            			<DropdownMenuSeparator />
+					</DropdownMenuItem>
+						<DropdownMenuSeparator />
 						<DropdownMenuItem disabled={activeLayoutId === 'auto'} onSelect={() => onEditCameras?.()}>
 							<SlidersHorizontal className="mr-2 h-4 w-4" />
 							Edit cameras

--- a/src/components/features/play/PlayLayoutControls.tsx
+++ b/src/components/features/play/PlayLayoutControls.tsx
@@ -7,7 +7,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { MoreHorizontal, Save, LayoutTemplate, Plus, Pencil, Trash2, SlidersHorizontal } from 'lucide-react';
+import { MoreHorizontal, Save, LayoutTemplate, Plus, Pencil, Trash2, SlidersHorizontal, Pin } from 'lucide-react';
 
 export interface LayoutOption {
 	id: string;
@@ -24,10 +24,13 @@ interface PlayLayoutControlsProps {
 	onSave: () => void;
   isDirty?: boolean;
   onEditCameras?: () => void;
+  defaultLayoutId?: string | null;
+  onSetDefault?: (id: string | 'auto') => void;
 }
 
 export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
-	layouts, activeLayoutId, onSelect, onCreate, onRename, onDelete, onSave, isDirty = false, onEditCameras,
+  layouts, activeLayoutId, onSelect, onCreate, onRename, onDelete, onSave, isDirty = false, onEditCameras,
+  defaultLayoutId = null, onSetDefault,
 }) => {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isRenameOpen, setIsRenameOpen] = useState(false);
@@ -48,7 +51,11 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 		onSelect(v as any);
 	};
 
-	return (
+  const orderedLayouts = React.useMemo(() => {
+    return [...layouts].sort((a, b) => a.name.localeCompare(b.name));
+  }, [layouts]);
+
+  return (
 		<div className="flex items-center gap-2">
 			<div className="inline-flex items-center gap-2 rounded-md bg-background/80 backdrop-blur-sm border px-1.5 py-1">
 				<LayoutTemplate className="h-4 w-4 text-muted-foreground" />
@@ -61,9 +68,19 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 							<span className="inline-flex items-center"><Plus className="mr-2 h-4 w-4" /> New layout…</span>
 						</SelectItem>
 						<SelectSeparator />
-						<SelectItem value="auto">Auto</SelectItem>
-						{layouts.map(l => (
-							<SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
+						<SelectItem value="auto">
+							<span className="inline-flex items-center">
+								<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === null ? '' : 'invisible'}`} />
+								<span>Auto</span>
+							</span>
+						</SelectItem>
+						{orderedLayouts.map(l => (
+							<SelectItem key={l.id} value={l.id}>
+								<span className="inline-flex items-center">
+									<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === l.id ? '' : 'invisible'}`} />
+									<span>{l.name}</span>
+								</span>
+							</SelectItem>
 						))}
 					</SelectContent>
 				</Select>
@@ -85,6 +102,13 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 						</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end">
+						<DropdownMenuItem
+						onSelect={() => { onSetDefault?.(activeLayoutId); }}
+						>
+						<Pin className="mr-2 h-4 w-4" />
+						Set as default
+						</DropdownMenuItem>
+            			<DropdownMenuSeparator />
 						<DropdownMenuItem disabled={activeLayoutId === 'auto'} onSelect={() => onEditCameras?.()}>
 							<SlidersHorizontal className="mr-2 h-4 w-4" />
 							Edit cameras

--- a/src/components/features/play/play-grid.tsx
+++ b/src/components/features/play/play-grid.tsx
@@ -127,7 +127,7 @@ export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, ini
 				return (
 				<div key={device.id} className="overflow-hidden grid-item-container">
 					<Card className="h-full w-full flex flex-col">
-						<CardHeader className="px-2 py-1.5 shrink-0 border-b bg-muted/40 rounded-t-lg">
+					<CardHeader className="px-2 py-1.5 shrink-0 bg-black text-white rounded-t-lg">
 						<div className="flex items-center justify-between gap-2">
 								<div className="min-w-0">
 								<CardTitle className="text-xs font-medium leading-tight truncate flex items-center gap-1.5" title={device.name}>

--- a/src/data/db/migrations/0029_kind_tombstone.sql
+++ b/src/data/db/migrations/0029_kind_tombstone.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `user_layout_preferences` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`default_layout_id` text,
+	`pinned_layout_ids` text DEFAULT '[]' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`default_layout_id`) REFERENCES `layouts`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_layout_preferences_user_org_unique_idx` ON `user_layout_preferences` (`user_id`,`organization_id`);--> statement-breakpoint
+CREATE INDEX `user_layout_preferences_user_idx` ON `user_layout_preferences` (`user_id`);--> statement-breakpoint
+CREATE INDEX `user_layout_preferences_org_idx` ON `user_layout_preferences` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `user_layout_preferences_default_layout_idx` ON `user_layout_preferences` (`default_layout_id`);

--- a/src/data/db/migrations/0030_futuristic_machine_man.sql
+++ b/src/data/db/migrations/0030_futuristic_machine_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_layout_preferences` DROP COLUMN `pinned_layout_ids`;

--- a/src/data/db/migrations/meta/0029_snapshot.json
+++ b/src/data/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,3587 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3ad1b252-2d85-44fe-b54b-921574e3c3f3",
+  "prevId": "eac93b44-e345-44c4-b773-0d22dc011b6b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_account_idx": {
+          "name": "provider_account_idx",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        },
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_audit_log": {
+      "name": "alarm_zone_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_audit_log_zone_created_idx": {
+          "name": "alarm_zone_audit_log_zone_created_idx",
+          "columns": [
+            "zone_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "alarm_zone_audit_log_user_created_idx": {
+          "name": "alarm_zone_audit_log_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "alarm_zone_audit_log_action_idx": {
+          "name": "alarm_zone_audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_audit_log_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_audit_log_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_audit_log",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alarm_zone_audit_log_user_id_user_id_fk": {
+          "name": "alarm_zone_audit_log_user_id_user_id_fk",
+          "tableFrom": "alarm_zone_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_devices": {
+      "name": "alarm_zone_devices",
+      "columns": {
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_devices_zone_idx": {
+          "name": "alarm_zone_devices_zone_idx",
+          "columns": [
+            "zone_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_devices_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_devices_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_devices",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alarm_zone_devices_device_id_devices_id_fk": {
+          "name": "alarm_zone_devices_device_id_devices_id_fk",
+          "tableFrom": "alarm_zone_devices",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_trigger_overrides": {
+      "name": "alarm_zone_trigger_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "should_trigger": {
+          "name": "should_trigger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_trigger_overrides_zone_event_type_idx": {
+          "name": "alarm_zone_trigger_overrides_zone_event_type_idx",
+          "columns": [
+            "zone_id",
+            "event_type"
+          ],
+          "isUnique": true
+        },
+        "alarm_zone_trigger_overrides_zone_idx": {
+          "name": "alarm_zone_trigger_overrides_zone_idx",
+          "columns": [
+            "zone_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_trigger_overrides_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_trigger_overrides_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_trigger_overrides",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zones": {
+      "name": "alarm_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "armed_state": {
+          "name": "armed_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DISARMED'"
+        },
+        "last_armed_state_change_reason": {
+          "name": "last_armed_state_change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_behavior": {
+          "name": "trigger_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zones_location_idx": {
+          "name": "alarm_zones_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        },
+        "alarm_zones_armed_state_idx": {
+          "name": "alarm_zones_armed_state_idx",
+          "columns": [
+            "armed_state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zones_location_id_locations_id_fk": {
+          "name": "alarm_zones_location_id_locations_id_fk",
+          "tableFrom": "alarm_zones",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_user_idx": {
+          "name": "apikey_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_enabled_idx": {
+          "name": "apikey_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "apikey_expires_at_idx": {
+          "name": "apikey_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "apikey_created_at_idx": {
+          "name": "apikey_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "apikey_updated_at_idx": {
+          "name": "apikey_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "arming_schedules": {
+      "name": "arming_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arm_time_local": {
+          "name": "arm_time_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disarm_time_local": {
+          "name": "disarm_time_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "arming_schedules_is_enabled_idx": {
+          "name": "arming_schedules_is_enabled_idx",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_action_executions": {
+      "name": "automation_action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_index": {
+          "name": "action_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_params": {
+          "name": "action_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_data": {
+          "name": "result_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automation_action_executions_execution_idx": {
+          "name": "automation_action_executions_execution_idx",
+          "columns": [
+            "execution_id"
+          ],
+          "isUnique": false
+        },
+        "automation_action_executions_status_idx": {
+          "name": "automation_action_executions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "automation_action_executions_type_idx": {
+          "name": "automation_action_executions_type_idx",
+          "columns": [
+            "action_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_action_executions_execution_id_automation_executions_id_fk": {
+          "name": "automation_action_executions_execution_id_automation_executions_id_fk",
+          "tableFrom": "automation_action_executions",
+          "tableTo": "automation_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_executions": {
+      "name": "automation_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_timestamp": {
+          "name": "trigger_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_conditions_met": {
+          "name": "state_conditions_met",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temporal_conditions_met": {
+          "name": "temporal_conditions_met",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_actions": {
+          "name": "total_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "successful_actions": {
+          "name": "successful_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_actions": {
+          "name": "failed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "automation_executions_automation_idx": {
+          "name": "automation_executions_automation_idx",
+          "columns": [
+            "automation_id"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_timestamp_idx": {
+          "name": "automation_executions_timestamp_idx",
+          "columns": [
+            "trigger_timestamp"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_trigger_event_idx": {
+          "name": "automation_executions_trigger_event_idx",
+          "columns": [
+            "trigger_event_id"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_status_idx": {
+          "name": "automation_executions_status_idx",
+          "columns": [
+            "execution_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_executions_automation_id_automations_id_fk": {
+          "name": "automation_executions_automation_id_automations_id_fk",
+          "tableFrom": "automation_executions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_scope_id": {
+          "name": "location_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "automations_tags_idx": {
+          "name": "automations_tags_idx",
+          "columns": [
+            "tags"
+          ],
+          "isUnique": false
+        },
+        "automations_organization_idx": {
+          "name": "automations_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_organization_id_organization_id_fk": {
+          "name": "automations_organization_id_organization_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_location_scope_id_locations_id_fk": {
+          "name": "automations_location_scope_id_locations_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cfg_enc": {
+          "name": "cfg_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events_enabled": {
+          "name": "events_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connectors_organization_idx": {
+          "name": "connectors_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organization_id_fk": {
+          "name": "connectors_organization_id_organization_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_overlays": {
+      "name": "device_overlays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "floor_plan_id": {
+          "name": "floor_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "props": {
+          "name": "props",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "device_overlays_device_floor_plan_unique_idx": {
+          "name": "device_overlays_device_floor_plan_unique_idx",
+          "columns": [
+            "device_id",
+            "floor_plan_id"
+          ],
+          "isUnique": true
+        },
+        "device_overlays_organization_idx": {
+          "name": "device_overlays_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "device_overlays_floor_plan_idx": {
+          "name": "device_overlays_floor_plan_idx",
+          "columns": [
+            "floor_plan_id"
+          ],
+          "isUnique": false
+        },
+        "device_overlays_device_idx": {
+          "name": "device_overlays_device_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_overlays_device_id_devices_id_fk": {
+          "name": "device_overlays_device_id_devices_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_floor_plan_id_floor_plans_id_fk": {
+          "name": "device_overlays_floor_plan_id_floor_plans_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "floor_plans",
+          "columnsFrom": [
+            "floor_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_organization_id_organization_id_fk": {
+          "name": "device_overlays_organization_id_organization_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_created_by_user_id_user_id_fk": {
+          "name": "device_overlays_created_by_user_id_user_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_updated_by_user_id_user_id_fk": {
+          "name": "device_overlays_updated_by_user_id_user_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "devices": {
+      "name": "devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_device_type": {
+          "name": "standardized_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standardized_device_subtype": {
+          "name": "standardized_device_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battery_percentage": {
+          "name": "battery_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_device_data": {
+          "name": "raw_device_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "devices_connector_device_unique_idx": {
+          "name": "devices_connector_device_unique_idx",
+          "columns": [
+            "connector_id",
+            "device_id"
+          ],
+          "isUnique": true
+        },
+        "devices_std_type_idx": {
+          "name": "devices_std_type_idx",
+          "columns": [
+            "standardized_device_type"
+          ],
+          "isUnique": false
+        },
+        "devices_std_subtype_idx": {
+          "name": "devices_std_subtype_idx",
+          "columns": [
+            "standardized_device_subtype"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "devices_connector_id_connectors_id_fk": {
+          "name": "devices_connector_id_connectors_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_category": {
+          "name": "standardized_event_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_type": {
+          "name": "standardized_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_subtype": {
+          "name": "standardized_event_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_event_type": {
+          "name": "raw_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standardized_payload": {
+          "name": "standardized_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_event_uuid_unique": {
+          "name": "events_event_uuid_unique",
+          "columns": [
+            "event_uuid"
+          ],
+          "isUnique": true
+        },
+        "events_timestamp_idx": {
+          "name": "events_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "events_connector_device_idx": {
+          "name": "events_connector_device_idx",
+          "columns": [
+            "connector_id",
+            "device_id"
+          ],
+          "isUnique": false
+        },
+        "events_event_type_idx": {
+          "name": "events_event_type_idx",
+          "columns": [
+            "standardized_event_type"
+          ],
+          "isUnique": false
+        },
+        "events_connector_category_timestamp_idx": {
+          "name": "events_connector_category_timestamp_idx",
+          "columns": [
+            "connector_id",
+            "standardized_event_category",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_connector_id_connectors_id_fk": {
+          "name": "events_connector_id_connectors_id_fk",
+          "tableFrom": "events",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "floor_plans": {
+      "name": "floor_plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "floor_plan_data": {
+          "name": "floor_plan_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "floor_plans_location_idx": {
+          "name": "floor_plans_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        },
+        "floor_plans_organization_idx": {
+          "name": "floor_plans_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "floor_plans_location_id_locations_id_fk": {
+          "name": "floor_plans_location_id_locations_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_organization_id_organization_id_fk": {
+          "name": "floor_plans_organization_id_organization_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_created_by_user_id_user_id_fk": {
+          "name": "floor_plans_created_by_user_id_user_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_updated_by_user_id_user_id_fk": {
+          "name": "floor_plans_updated_by_user_id_user_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_email_org_idx": {
+          "name": "invitation_email_org_idx",
+          "columns": [
+            "email",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            "inviterId"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keypad_pins": {
+      "name": "keypad_pins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keypad_pin": {
+          "name": "keypad_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "keypad_pins_org_pin_unique_idx": {
+          "name": "keypad_pins_org_pin_unique_idx",
+          "columns": [
+            "organization_id",
+            "keypad_pin"
+          ],
+          "isUnique": true
+        },
+        "keypad_pins_user_org_unique_idx": {
+          "name": "keypad_pins_user_org_unique_idx",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "keypad_pins_organization_idx": {
+          "name": "keypad_pins_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "keypad_pins_user_idx": {
+          "name": "keypad_pins_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keypad_pins_user_id_user_id_fk": {
+          "name": "keypad_pins_user_id_user_id_fk",
+          "tableFrom": "keypad_pins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keypad_pins_organization_id_organization_id_fk": {
+          "name": "keypad_pins_organization_id_organization_id_fk",
+          "tableFrom": "keypad_pins",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "layouts": {
+      "name": "layouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_ids": {
+          "name": "device_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "layouts_organization_idx": {
+          "name": "layouts_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "layouts_created_by_idx": {
+          "name": "layouts_created_by_idx",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "layouts_updated_by_idx": {
+          "name": "layouts_updated_by_idx",
+          "columns": [
+            "updated_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "layouts_organization_id_organization_id_fk": {
+          "name": "layouts_organization_id_organization_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "layouts_created_by_user_id_user_id_fk": {
+          "name": "layouts_created_by_user_id_user_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "layouts_updated_by_user_id_user_id_fk": {
+          "name": "layouts_updated_by_user_id_user_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_postal_code": {
+          "name": "address_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_arming_schedule_id": {
+          "name": "active_arming_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sunrise_time": {
+          "name": "sunrise_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sunset_time": {
+          "name": "sunset_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sun_times_updated_at": {
+          "name": "sun_times_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "locations_parent_idx": {
+          "name": "locations_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "locations_organization_idx": {
+          "name": "locations_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "locations_path_idx": {
+          "name": "locations_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "locations_active_arming_schedule_idx": {
+          "name": "locations_active_arming_schedule_idx",
+          "columns": [
+            "active_arming_schedule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "locations_parent_id_locations_id_fk": {
+          "name": "locations_parent_id_locations_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_organization_id_organization_id_fk": {
+          "name": "locations_organization_id_organization_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_active_arming_schedule_id_arming_schedules_id_fk": {
+          "name": "locations_active_arming_schedule_id_arming_schedules_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "arming_schedules",
+          "columnsFrom": [
+            "active_arming_schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_user_org_idx": {
+          "name": "member_user_org_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": true
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "member_org_idx": {
+          "name": "member_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_idx": {
+          "name": "organization_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_settings": {
+      "name": "organization_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_settings_org_type_unique_idx": {
+          "name": "organization_settings_org_type_unique_idx",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "organization_settings_organization_idx": {
+          "name": "organization_settings_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_settings_type_idx": {
+          "name": "organization_settings_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "piko_servers": {
+      "name": "piko_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os_platform": {
+          "name": "os_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os_variant_version": {
+          "name": "os_variant_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "piko_servers_connector_idx": {
+          "name": "piko_servers_connector_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "piko_servers_connector_id_connectors_id_fk": {
+          "name": "piko_servers_connector_id_connectors_id_fk",
+          "tableFrom": "piko_servers",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_configurations": {
+      "name": "service_configurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_enc": {
+          "name": "config_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "session_active_org_idx": {
+          "name": "session_active_org_idx",
+          "columns": [
+            "activeOrganizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_activeOrganizationId_organization_id_fk": {
+          "name": "session_activeOrganizationId_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "activeOrganizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "space_devices": {
+      "name": "space_devices",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "space_devices_space_idx": {
+          "name": "space_devices_space_idx",
+          "columns": [
+            "space_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "space_devices_space_id_spaces_id_fk": {
+          "name": "space_devices_space_id_spaces_id_fk",
+          "tableFrom": "space_devices",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_devices_device_id_devices_id_fk": {
+          "name": "space_devices_device_id_devices_id_fk",
+          "tableFrom": "space_devices",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spaces_location_idx": {
+          "name": "spaces_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "spaces_location_id_locations_id_fk": {
+          "name": "spaces_location_id_locations_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twoFactor": {
+      "name": "twoFactor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_unique": {
+          "name": "twoFactor_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "twoFactor_user_idx": {
+          "name": "twoFactor_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "twoFactor_userId_user_id_fk": {
+          "name": "twoFactor_userId_user_id_fk",
+          "tableFrom": "twoFactor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_layout_preferences": {
+      "name": "user_layout_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_layout_id": {
+          "name": "default_layout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_layout_ids": {
+          "name": "pinned_layout_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_layout_preferences_user_org_unique_idx": {
+          "name": "user_layout_preferences_user_org_unique_idx",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "user_layout_preferences_user_idx": {
+          "name": "user_layout_preferences_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_layout_preferences_org_idx": {
+          "name": "user_layout_preferences_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "user_layout_preferences_default_layout_idx": {
+          "name": "user_layout_preferences_default_layout_idx",
+          "columns": [
+            "default_layout_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_layout_preferences_user_id_user_id_fk": {
+          "name": "user_layout_preferences_user_id_user_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_layout_preferences_organization_id_organization_id_fk": {
+          "name": "user_layout_preferences_organization_id_organization_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_layout_preferences_default_layout_id_layouts_id_fk": {
+          "name": "user_layout_preferences_default_layout_id_layouts_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "default_layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_value_idx": {
+          "name": "verification_identifier_value_idx",
+          "columns": [
+            "identifier",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/data/db/migrations/meta/0030_snapshot.json
+++ b/src/data/db/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3579 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d6a900d8-06ab-4e5c-bc73-85e341923fde",
+  "prevId": "3ad1b252-2d85-44fe-b54b-921574e3c3f3",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_account_idx": {
+          "name": "provider_account_idx",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        },
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_audit_log": {
+      "name": "alarm_zone_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_audit_log_zone_created_idx": {
+          "name": "alarm_zone_audit_log_zone_created_idx",
+          "columns": [
+            "zone_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "alarm_zone_audit_log_user_created_idx": {
+          "name": "alarm_zone_audit_log_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "alarm_zone_audit_log_action_idx": {
+          "name": "alarm_zone_audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_audit_log_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_audit_log_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_audit_log",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alarm_zone_audit_log_user_id_user_id_fk": {
+          "name": "alarm_zone_audit_log_user_id_user_id_fk",
+          "tableFrom": "alarm_zone_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_devices": {
+      "name": "alarm_zone_devices",
+      "columns": {
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_devices_zone_idx": {
+          "name": "alarm_zone_devices_zone_idx",
+          "columns": [
+            "zone_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_devices_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_devices_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_devices",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alarm_zone_devices_device_id_devices_id_fk": {
+          "name": "alarm_zone_devices_device_id_devices_id_fk",
+          "tableFrom": "alarm_zone_devices",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zone_trigger_overrides": {
+      "name": "alarm_zone_trigger_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "should_trigger": {
+          "name": "should_trigger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zone_trigger_overrides_zone_event_type_idx": {
+          "name": "alarm_zone_trigger_overrides_zone_event_type_idx",
+          "columns": [
+            "zone_id",
+            "event_type"
+          ],
+          "isUnique": true
+        },
+        "alarm_zone_trigger_overrides_zone_idx": {
+          "name": "alarm_zone_trigger_overrides_zone_idx",
+          "columns": [
+            "zone_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zone_trigger_overrides_zone_id_alarm_zones_id_fk": {
+          "name": "alarm_zone_trigger_overrides_zone_id_alarm_zones_id_fk",
+          "tableFrom": "alarm_zone_trigger_overrides",
+          "tableTo": "alarm_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alarm_zones": {
+      "name": "alarm_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "armed_state": {
+          "name": "armed_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DISARMED'"
+        },
+        "last_armed_state_change_reason": {
+          "name": "last_armed_state_change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_behavior": {
+          "name": "trigger_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alarm_zones_location_idx": {
+          "name": "alarm_zones_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        },
+        "alarm_zones_armed_state_idx": {
+          "name": "alarm_zones_armed_state_idx",
+          "columns": [
+            "armed_state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alarm_zones_location_id_locations_id_fk": {
+          "name": "alarm_zones_location_id_locations_id_fk",
+          "tableFrom": "alarm_zones",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_user_idx": {
+          "name": "apikey_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_enabled_idx": {
+          "name": "apikey_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "apikey_expires_at_idx": {
+          "name": "apikey_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "apikey_created_at_idx": {
+          "name": "apikey_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "apikey_updated_at_idx": {
+          "name": "apikey_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "arming_schedules": {
+      "name": "arming_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arm_time_local": {
+          "name": "arm_time_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disarm_time_local": {
+          "name": "disarm_time_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "arming_schedules_is_enabled_idx": {
+          "name": "arming_schedules_is_enabled_idx",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_action_executions": {
+      "name": "automation_action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_index": {
+          "name": "action_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_params": {
+          "name": "action_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_data": {
+          "name": "result_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automation_action_executions_execution_idx": {
+          "name": "automation_action_executions_execution_idx",
+          "columns": [
+            "execution_id"
+          ],
+          "isUnique": false
+        },
+        "automation_action_executions_status_idx": {
+          "name": "automation_action_executions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "automation_action_executions_type_idx": {
+          "name": "automation_action_executions_type_idx",
+          "columns": [
+            "action_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_action_executions_execution_id_automation_executions_id_fk": {
+          "name": "automation_action_executions_execution_id_automation_executions_id_fk",
+          "tableFrom": "automation_action_executions",
+          "tableTo": "automation_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_executions": {
+      "name": "automation_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_timestamp": {
+          "name": "trigger_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_conditions_met": {
+          "name": "state_conditions_met",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temporal_conditions_met": {
+          "name": "temporal_conditions_met",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_actions": {
+          "name": "total_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "successful_actions": {
+          "name": "successful_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_actions": {
+          "name": "failed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "automation_executions_automation_idx": {
+          "name": "automation_executions_automation_idx",
+          "columns": [
+            "automation_id"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_timestamp_idx": {
+          "name": "automation_executions_timestamp_idx",
+          "columns": [
+            "trigger_timestamp"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_trigger_event_idx": {
+          "name": "automation_executions_trigger_event_idx",
+          "columns": [
+            "trigger_event_id"
+          ],
+          "isUnique": false
+        },
+        "automation_executions_status_idx": {
+          "name": "automation_executions_status_idx",
+          "columns": [
+            "execution_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_executions_automation_id_automations_id_fk": {
+          "name": "automation_executions_automation_id_automations_id_fk",
+          "tableFrom": "automation_executions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_scope_id": {
+          "name": "location_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now', 'subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "automations_tags_idx": {
+          "name": "automations_tags_idx",
+          "columns": [
+            "tags"
+          ],
+          "isUnique": false
+        },
+        "automations_organization_idx": {
+          "name": "automations_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_organization_id_organization_id_fk": {
+          "name": "automations_organization_id_organization_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_location_scope_id_locations_id_fk": {
+          "name": "automations_location_scope_id_locations_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cfg_enc": {
+          "name": "cfg_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events_enabled": {
+          "name": "events_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connectors_organization_idx": {
+          "name": "connectors_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organization_id_fk": {
+          "name": "connectors_organization_id_organization_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_overlays": {
+      "name": "device_overlays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "floor_plan_id": {
+          "name": "floor_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "props": {
+          "name": "props",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "device_overlays_device_floor_plan_unique_idx": {
+          "name": "device_overlays_device_floor_plan_unique_idx",
+          "columns": [
+            "device_id",
+            "floor_plan_id"
+          ],
+          "isUnique": true
+        },
+        "device_overlays_organization_idx": {
+          "name": "device_overlays_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "device_overlays_floor_plan_idx": {
+          "name": "device_overlays_floor_plan_idx",
+          "columns": [
+            "floor_plan_id"
+          ],
+          "isUnique": false
+        },
+        "device_overlays_device_idx": {
+          "name": "device_overlays_device_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_overlays_device_id_devices_id_fk": {
+          "name": "device_overlays_device_id_devices_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_floor_plan_id_floor_plans_id_fk": {
+          "name": "device_overlays_floor_plan_id_floor_plans_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "floor_plans",
+          "columnsFrom": [
+            "floor_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_organization_id_organization_id_fk": {
+          "name": "device_overlays_organization_id_organization_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_created_by_user_id_user_id_fk": {
+          "name": "device_overlays_created_by_user_id_user_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_overlays_updated_by_user_id_user_id_fk": {
+          "name": "device_overlays_updated_by_user_id_user_id_fk",
+          "tableFrom": "device_overlays",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "devices": {
+      "name": "devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_device_type": {
+          "name": "standardized_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standardized_device_subtype": {
+          "name": "standardized_device_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "battery_percentage": {
+          "name": "battery_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_device_data": {
+          "name": "raw_device_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "devices_connector_device_unique_idx": {
+          "name": "devices_connector_device_unique_idx",
+          "columns": [
+            "connector_id",
+            "device_id"
+          ],
+          "isUnique": true
+        },
+        "devices_std_type_idx": {
+          "name": "devices_std_type_idx",
+          "columns": [
+            "standardized_device_type"
+          ],
+          "isUnique": false
+        },
+        "devices_std_subtype_idx": {
+          "name": "devices_std_subtype_idx",
+          "columns": [
+            "standardized_device_subtype"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "devices_connector_id_connectors_id_fk": {
+          "name": "devices_connector_id_connectors_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_category": {
+          "name": "standardized_event_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_type": {
+          "name": "standardized_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "standardized_event_subtype": {
+          "name": "standardized_event_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_event_type": {
+          "name": "raw_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standardized_payload": {
+          "name": "standardized_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_event_uuid_unique": {
+          "name": "events_event_uuid_unique",
+          "columns": [
+            "event_uuid"
+          ],
+          "isUnique": true
+        },
+        "events_timestamp_idx": {
+          "name": "events_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "events_connector_device_idx": {
+          "name": "events_connector_device_idx",
+          "columns": [
+            "connector_id",
+            "device_id"
+          ],
+          "isUnique": false
+        },
+        "events_event_type_idx": {
+          "name": "events_event_type_idx",
+          "columns": [
+            "standardized_event_type"
+          ],
+          "isUnique": false
+        },
+        "events_connector_category_timestamp_idx": {
+          "name": "events_connector_category_timestamp_idx",
+          "columns": [
+            "connector_id",
+            "standardized_event_category",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_connector_id_connectors_id_fk": {
+          "name": "events_connector_id_connectors_id_fk",
+          "tableFrom": "events",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "floor_plans": {
+      "name": "floor_plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "floor_plan_data": {
+          "name": "floor_plan_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "floor_plans_location_idx": {
+          "name": "floor_plans_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        },
+        "floor_plans_organization_idx": {
+          "name": "floor_plans_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "floor_plans_location_id_locations_id_fk": {
+          "name": "floor_plans_location_id_locations_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_organization_id_organization_id_fk": {
+          "name": "floor_plans_organization_id_organization_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_created_by_user_id_user_id_fk": {
+          "name": "floor_plans_created_by_user_id_user_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_plans_updated_by_user_id_user_id_fk": {
+          "name": "floor_plans_updated_by_user_id_user_id_fk",
+          "tableFrom": "floor_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_email_org_idx": {
+          "name": "invitation_email_org_idx",
+          "columns": [
+            "email",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            "inviterId"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keypad_pins": {
+      "name": "keypad_pins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keypad_pin": {
+          "name": "keypad_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "keypad_pins_org_pin_unique_idx": {
+          "name": "keypad_pins_org_pin_unique_idx",
+          "columns": [
+            "organization_id",
+            "keypad_pin"
+          ],
+          "isUnique": true
+        },
+        "keypad_pins_user_org_unique_idx": {
+          "name": "keypad_pins_user_org_unique_idx",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "keypad_pins_organization_idx": {
+          "name": "keypad_pins_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "keypad_pins_user_idx": {
+          "name": "keypad_pins_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keypad_pins_user_id_user_id_fk": {
+          "name": "keypad_pins_user_id_user_id_fk",
+          "tableFrom": "keypad_pins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keypad_pins_organization_id_organization_id_fk": {
+          "name": "keypad_pins_organization_id_organization_id_fk",
+          "tableFrom": "keypad_pins",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "layouts": {
+      "name": "layouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_ids": {
+          "name": "device_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "layouts_organization_idx": {
+          "name": "layouts_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "layouts_created_by_idx": {
+          "name": "layouts_created_by_idx",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "layouts_updated_by_idx": {
+          "name": "layouts_updated_by_idx",
+          "columns": [
+            "updated_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "layouts_organization_id_organization_id_fk": {
+          "name": "layouts_organization_id_organization_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "layouts_created_by_user_id_user_id_fk": {
+          "name": "layouts_created_by_user_id_user_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "layouts_updated_by_user_id_user_id_fk": {
+          "name": "layouts_updated_by_user_id_user_id_fk",
+          "tableFrom": "layouts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_postal_code": {
+          "name": "address_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_arming_schedule_id": {
+          "name": "active_arming_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sunrise_time": {
+          "name": "sunrise_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sunset_time": {
+          "name": "sunset_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sun_times_updated_at": {
+          "name": "sun_times_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "locations_parent_idx": {
+          "name": "locations_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "locations_organization_idx": {
+          "name": "locations_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "locations_path_idx": {
+          "name": "locations_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "locations_active_arming_schedule_idx": {
+          "name": "locations_active_arming_schedule_idx",
+          "columns": [
+            "active_arming_schedule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "locations_parent_id_locations_id_fk": {
+          "name": "locations_parent_id_locations_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_organization_id_organization_id_fk": {
+          "name": "locations_organization_id_organization_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_active_arming_schedule_id_arming_schedules_id_fk": {
+          "name": "locations_active_arming_schedule_id_arming_schedules_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "arming_schedules",
+          "columnsFrom": [
+            "active_arming_schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_user_org_idx": {
+          "name": "member_user_org_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": true
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "member_org_idx": {
+          "name": "member_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_idx": {
+          "name": "organization_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_settings": {
+      "name": "organization_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_settings_org_type_unique_idx": {
+          "name": "organization_settings_org_type_unique_idx",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "organization_settings_organization_idx": {
+          "name": "organization_settings_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_settings_type_idx": {
+          "name": "organization_settings_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "piko_servers": {
+      "name": "piko_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os_platform": {
+          "name": "os_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os_variant_version": {
+          "name": "os_variant_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "piko_servers_connector_idx": {
+          "name": "piko_servers_connector_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "piko_servers_connector_id_connectors_id_fk": {
+          "name": "piko_servers_connector_id_connectors_id_fk",
+          "tableFrom": "piko_servers",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_configurations": {
+      "name": "service_configurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_enc": {
+          "name": "config_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "session_active_org_idx": {
+          "name": "session_active_org_idx",
+          "columns": [
+            "activeOrganizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_activeOrganizationId_organization_id_fk": {
+          "name": "session_activeOrganizationId_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "activeOrganizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "space_devices": {
+      "name": "space_devices",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "space_devices_space_idx": {
+          "name": "space_devices_space_idx",
+          "columns": [
+            "space_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "space_devices_space_id_spaces_id_fk": {
+          "name": "space_devices_space_id_spaces_id_fk",
+          "tableFrom": "space_devices",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_devices_device_id_devices_id_fk": {
+          "name": "space_devices_device_id_devices_id_fk",
+          "tableFrom": "space_devices",
+          "tableTo": "devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spaces_location_idx": {
+          "name": "spaces_location_idx",
+          "columns": [
+            "location_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "spaces_location_id_locations_id_fk": {
+          "name": "spaces_location_id_locations_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twoFactor": {
+      "name": "twoFactor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_unique": {
+          "name": "twoFactor_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "twoFactor_user_idx": {
+          "name": "twoFactor_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "twoFactor_userId_user_id_fk": {
+          "name": "twoFactor_userId_user_id_fk",
+          "tableFrom": "twoFactor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_layout_preferences": {
+      "name": "user_layout_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_layout_id": {
+          "name": "default_layout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_layout_preferences_user_org_unique_idx": {
+          "name": "user_layout_preferences_user_org_unique_idx",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "user_layout_preferences_user_idx": {
+          "name": "user_layout_preferences_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_layout_preferences_org_idx": {
+          "name": "user_layout_preferences_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "user_layout_preferences_default_layout_idx": {
+          "name": "user_layout_preferences_default_layout_idx",
+          "columns": [
+            "default_layout_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_layout_preferences_user_id_user_id_fk": {
+          "name": "user_layout_preferences_user_id_user_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_layout_preferences_organization_id_organization_id_fk": {
+          "name": "user_layout_preferences_organization_id_organization_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_layout_preferences_default_layout_id_layouts_id_fk": {
+          "name": "user_layout_preferences_default_layout_id_layouts_id_fk",
+          "tableFrom": "user_layout_preferences",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "default_layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_value_idx": {
+          "name": "verification_identifier_value_idx",
+          "columns": [
+            "identifier",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/data/db/migrations/meta/_journal.json
+++ b/src/data/db/migrations/meta/_journal.json
@@ -204,6 +204,20 @@
       "when": 1755084973251,
       "tag": "0028_petite_colonel_america",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1755104193219,
+      "tag": "0029_kind_tombstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1755105766229,
+      "tag": "0030_futuristic_machine_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/data/db/schema.ts
+++ b/src/data/db/schema.ts
@@ -885,3 +885,33 @@ export const layoutsRelations = relations(layouts, ({ one }) => ({
     relationName: 'layoutUpdatedBy',
   }),
 }));
+
+// --- User Layout Preferences (per-user, per-organization) ---
+export const userLayoutPreferences = sqliteTable("user_layout_preferences", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  organizationId: text("organization_id").notNull().references(() => organization.id, { onDelete: "cascade" }),
+  defaultLayoutId: text("default_layout_id").references(() => layouts.id, { onDelete: 'set null' }),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+}, (table) => ({
+  userOrgUniqueIdx: uniqueIndex("user_layout_preferences_user_org_unique_idx").on(table.userId, table.organizationId),
+  userIdx: index("user_layout_preferences_user_idx").on(table.userId),
+  orgIdx: index("user_layout_preferences_org_idx").on(table.organizationId),
+  defaultLayoutIdx: index("user_layout_preferences_default_layout_idx").on(table.defaultLayoutId),
+}));
+
+export const userLayoutPreferencesRelations = relations(userLayoutPreferences, ({ one }) => ({
+  user: one(user, {
+    fields: [userLayoutPreferences.userId],
+    references: [user.id],
+  }),
+  organization: one(organization, {
+    fields: [userLayoutPreferences.organizationId],
+    references: [organization.id],
+  }),
+  defaultLayout: one(layouts, {
+    fields: [userLayoutPreferences.defaultLayoutId],
+    references: [layouts.id],
+  }),
+}));

--- a/src/lib/actions/user-actions.ts
+++ b/src/lib/actions/user-actions.ts
@@ -90,6 +90,7 @@ export async function updateUser(
         id: formData.get('id'),
         name: formData.get('name'),
         image: formData.get('image'),
+        role: formData.get('role'),
     };
 
     const validatedFields = UpdateUserSchema.safeParse(rawData);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -497,6 +497,9 @@
   box-sizing: border-box;
   background-image: none !important;
   border: none !important;
+  /* Ensure resize handles sit above overlays (e.g., error/loading UI) */
+  z-index: 50;
+  pointer-events: auto;
 }
 
 /* Hide resize handles completely even on hover */


### PR DESCRIPTION
This pull request introduces a user-specific default layout feature for the Play page, allowing users to set, persist, and retrieve their preferred layout across sessions. It adds backend support for storing these preferences per user and per organization, updates the API and database schema, and enhances the UI to reflect and manage the default layout selection. Several minor UI improvements and bug fixes are also included.

**Default Layout Preference Feature**

* Added a new `user_layout_preferences` table to the database schema to store each user's default layout per organization, with supporting migration files and schema definitions. [[1]](diffhunk://#diff-71065d024e8492177234b6394738c9f24a6802d51eb338e43d0003762ad072ccR1-R17) [[2]](diffhunk://#diff-0472aa962ceac785e42d0b7f1244ee81ea0a60fa9dd3125f82f1b09e0c50b041R1) [[3]](diffhunk://#diff-e6281e42e34251d8c9747cdfd11a6523ca7ff90bf2103b61d5d928f7719a40caR888-R917) [[4]](diffhunk://#diff-317324df91cd152f68500cf6f48609535437813dedaf7f6338beeaec8392a57dR207-R220)
* Implemented the `/api/play/preferences` API route with GET and PATCH methods for retrieving and updating a user's default layout preference, including validation and upsert logic.
* Updated the Play page (`page.tsx`) to load and apply the user's default layout on mount, handle preference updates when layouts are deleted or set as default, and sync UI state accordingly. [[1]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R47) [[2]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783L55-R77) [[3]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R158-R160) [[4]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R288-R296)

**UI Enhancements for Layout Selection**

* Enhanced the layout selection dropdown in `PlayLayoutControls` to visually indicate the default layout using a pin icon, sort layouts alphabetically, and provide a menu option to set the current layout as default. [[1]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009L10-R10) [[2]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009R27-R33) [[3]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009R54-R57) [[4]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009L64-R83) [[5]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009R105-R111)

**Minor UI and Bug Fixes**

* Updated card header styling for camera grids and play grid components to improve visual consistency. [[1]](diffhunk://#diff-f61647a0af528b9c011f577209e83ca585f15ee18590b60ff09ab4bd5c292bceL122-R122) [[2]](diffhunk://#diff-8e1129904c22ddabb69885490846f4df8bd068a021fa761d4c7e1bab5ace2b77L130-R130)
* Fixed z-index for grid resize handles to ensure proper layering over overlays.

**Account/User Table Improvements**

* Ensured the user's role is included in the edit user dialog and properly handled in user update actions. [[1]](diffhunk://#diff-d838df30988d060e997fdb769d52c527f6f9498585a22b2de4e707b824392fcbR578) [[2]](diffhunk://#diff-c01ff933f904aed5abf4d0086a1b36faefba491b4d60a685f069ca29f6dc8b6bR93)