### PR TITLE
Add view settings and video stats to play grid

### DIFF
--- a/src/app/(features)/play/page.tsx
+++ b/src/app/(features)/play/page.tsx
@@ -55,7 +55,6 @@ export default function PlayPage() {
     const v = window.localStorage.getItem('fusion.play.showInfo');
     return v === '1';
   });
-  const [showFps, setShowFps] = useState(false);
   const [prefs, setPrefs] = useState<{ defaultLayoutId: string | null }>({
     defaultLayoutId: null,
   });

--- a/src/app/(features)/play/page.tsx
+++ b/src/app/(features)/play/page.tsx
@@ -5,7 +5,10 @@ import { useFusionStore } from "@/stores/store";
 import { DeviceType } from "@/lib/mappings/definitions";
 import type { DeviceWithConnector } from "@/types";
 import { PageHeader } from "@/components/layout/page-header";
-import { Maximize, Minimize, MonitorPlay } from "lucide-react";
+import { Maximize, Minimize, MonitorPlay, Settings } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { LocationSpaceSelector } from "@/components/common/LocationSpaceSelector";
 import { PlayGrid } from "@/components/features/play/play-grid";
 import type { Layout } from "react-grid-layout";
@@ -41,6 +44,18 @@ export default function PlayPage() {
     new Set()
   );
   const [editSearch, setEditSearch] = useState("");
+  const [overlayHeaders, setOverlayHeaders] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    const v = window.localStorage.getItem('fusion.play.overlayHeaders');
+    return v === null ? true : v === '1';
+  });
+  const [isViewSettingsOpen, setIsViewSettingsOpen] = useState(false);
+  const [showInfo, setShowInfo] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const v = window.localStorage.getItem('fusion.play.showInfo');
+    return v === '1';
+  });
+  const [showFps, setShowFps] = useState(false);
   const [prefs, setPrefs] = useState<{ defaultLayoutId: string | null }>({
     defaultLayoutId: null,
   });
@@ -359,6 +374,22 @@ export default function PlayPage() {
               variant="outline"
               size="sm"
               className="h-9 px-3"
+              onClick={() => setIsViewSettingsOpen(true)}
+              aria-label="View settings"
+            >
+              <Settings className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>View settings</p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 px-3"
               onClick={togglePlayFullScreen}
             >
               {isPlayFullScreen ? (
@@ -389,6 +420,7 @@ export default function PlayPage() {
             setIsEditDialogOpen(true);
           }}
           defaultLayoutId={prefs.defaultLayoutId}
+          
           onSetDefault={async (id) => {
             const defaultLayoutId = id === "auto" ? null : id;
             setPrefs((prev) => ({ ...prev, defaultLayoutId }));
@@ -416,6 +448,44 @@ export default function PlayPage() {
           applyEditCameras(ids);
         }}
       />
+      <Dialog open={isViewSettingsOpen} onOpenChange={setIsViewSettingsOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Settings className="h-4 w-4 text-muted-foreground" />
+              View Settings
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex items-center justify-between py-1">
+            <div className="space-y-0.5">
+              <Label htmlFor="overlay-toggle">Overlay header over video</Label>
+            </div>
+            <Switch
+              id="overlay-toggle"
+              checked={overlayHeaders}
+              onCheckedChange={(v) => {
+                const nv = Boolean(v);
+                setOverlayHeaders(nv);
+                try { window.localStorage.setItem('fusion.play.overlayHeaders', nv ? '1' : '0'); } catch {}
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-between py-1">
+            <div className="space-y-0.5">
+              <Label htmlFor="info-toggle">Show info</Label>
+            </div>
+            <Switch
+              id="info-toggle"
+              checked={showInfo}
+              onCheckedChange={(v) => {
+                const nv = Boolean(v);
+                setShowInfo(nv);
+                try { window.localStorage.setItem('fusion.play.showInfo', nv ? '1' : '0'); } catch {}
+              }}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 
@@ -459,6 +529,8 @@ export default function PlayPage() {
               onAddCameras={() => setIsEditDialogOpen(true)}
               spaces={spaces}
               locations={locations}
+              overlayHeaders={overlayHeaders}
+              showInfo={showInfo}
               key={`grid-fs-${activeLayout?.id || "auto"}`}
             />
           )}
@@ -488,8 +560,10 @@ export default function PlayPage() {
               activeLayoutId === "auto" ? undefined : handleRemoveFromLayout
             }
             onAddCameras={() => setIsEditDialogOpen(true)}
-            spaces={spaces}
-            locations={locations}
+             spaces={spaces}
+             locations={locations}
+             overlayHeaders={overlayHeaders}
+             showInfo={showInfo}
             key={`grid-${activeLayout?.id || "auto"}`}
           />
         )}

--- a/src/components/features/piko/piko-video-player.tsx
+++ b/src/components/features/piko/piko-video-player.tsx
@@ -317,7 +317,7 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
     let lastTime = performance.now();
     const tick = () => {
       const quality = video.getVideoPlaybackQuality?.();
-      const frames = quality?.totalVideoFrames ?? video.webkitDecodedFrameCount ?? 0;
+      const frames = quality?.totalVideoFrames ?? 0;
       const now = performance.now();
       const dt = now - lastTime;
       if (dt >= 800 && onStats) {

--- a/src/components/features/piko/piko-video-player.tsx
+++ b/src/components/features/piko/piko-video-player.tsx
@@ -305,8 +305,13 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
       };
       statsRvfcRef.current = video.requestVideoFrameCallback(rVFC);
       return () => {
-        if (statsRvfcRef.current && typeof video.cancelVideoFrameCallback === 'function') {
-          video.cancelVideoFrameCallback(statsRvfcRef.current);
+        const cleanupVideo: any = video;
+        if (
+          statsRvfcRef.current &&
+          cleanupVideo &&
+          typeof cleanupVideo.cancelVideoFrameCallback === 'function'
+        ) {
+          cleanupVideo.cancelVideoFrameCallback(statsRvfcRef.current);
         }
         statsRvfcRef.current = null;
       };

--- a/src/components/features/piko/piko-video-player.tsx
+++ b/src/components/features/piko/piko-video-player.tsx
@@ -21,6 +21,8 @@ interface WebRTCConnectionDetails {
   connectionType: 'cloud' | 'local' | string;
 }
 
+interface PikoVideoStats { fps: number; width?: number; height?: number }
+
 interface PikoVideoPlayerProps {
   connectorId: string;
   pikoSystemId?: string;
@@ -28,6 +30,8 @@ interface PikoVideoPlayerProps {
   positionMs?: number;
   className?: string;
   disableFullscreen?: boolean;
+  enableStats?: boolean;
+  onStats?: (stats: PikoVideoStats) => void;
 }
 
 export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
@@ -36,7 +40,9 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
   cameraId,
   positionMs,
   className,
-  disableFullscreen = false
+  disableFullscreen = false,
+  enableStats = false,
+  onStats,
 }) => {
   const [isLoadingMediaInfo, setIsLoadingMediaInfo] = useState(true);
   const [mediaInfoError, setMediaInfoError] = useState<string | null>(null);
@@ -56,6 +62,8 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamManagerSubscriptionRef = useRef<DisposableSubscription | null>(null);
+  const statsRafRef = useRef<number | null>(null);
+  const statsRvfcRef = useRef<number | null>(null);
 
   // Dynamic import of the WebRTC library on the client side only
   useEffect(() => {
@@ -274,6 +282,61 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
     }
   }, [fetchedPikoSystemId, fetchedAccessToken, cameraId, positionMs, fetchedConnectionType, isLoadingMediaInfo, webrtcLib]);
 
+  // Optional FPS stats collection, strictly gated by enableStats
+  useEffect(() => {
+    if (!enableStats || !videoRef.current) return;
+    const video = videoRef.current as any;
+
+    // Prefer requestVideoFrameCallback when available
+    if (typeof video.requestVideoFrameCallback === 'function') {
+      const timestamps: number[] = [];
+      const rVFC = (now: number) => {
+        timestamps.push(now);
+        while (timestamps.length && timestamps[0] < now - 1000) timestamps.shift();
+        if (timestamps.length > 1 && onStats) {
+          const span = now - timestamps[0];
+          const fps = span > 0 ? ((timestamps.length - 1) * 1000) / span : 0;
+          const vw = (video as HTMLVideoElement).videoWidth;
+          const vh = (video as HTMLVideoElement).videoHeight;
+          onStats({ fps, width: vw || undefined, height: vh || undefined });
+        }
+        // keep sampling even when frames are static; rVFC fires on painted frames only
+        statsRvfcRef.current = video.requestVideoFrameCallback(rVFC);
+      };
+      statsRvfcRef.current = video.requestVideoFrameCallback(rVFC);
+      return () => {
+        if (statsRvfcRef.current && typeof video.cancelVideoFrameCallback === 'function') {
+          video.cancelVideoFrameCallback(statsRvfcRef.current);
+        }
+        statsRvfcRef.current = null;
+      };
+    }
+
+    // Fallback: sample decoded frames per second
+    let lastFrames = 0;
+    let lastTime = performance.now();
+    const tick = () => {
+      const quality = video.getVideoPlaybackQuality?.();
+      const frames = quality?.totalVideoFrames ?? video.webkitDecodedFrameCount ?? 0;
+      const now = performance.now();
+      const dt = now - lastTime;
+      if (dt >= 800 && onStats) {
+        const fps = Math.max(0, ((frames - lastFrames) * 1000) / dt);
+        const vw = (video as HTMLVideoElement).videoWidth;
+        const vh = (video as HTMLVideoElement).videoHeight;
+        onStats({ fps, width: vw || undefined, height: vh || undefined });
+        lastFrames = frames;
+        lastTime = now;
+      }
+      statsRafRef.current = requestAnimationFrame(tick);
+    };
+    statsRafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (statsRafRef.current) cancelAnimationFrame(statsRafRef.current);
+      statsRafRef.current = null;
+    };
+  }, [enableStats, onStats]);
+
   return (
     <div className={`relative aspect-video bg-muted rounded-md overflow-hidden flex items-center justify-center ${className}`}>
         {(isLoadingMediaInfo || (!fetchedPikoSystemId && !fetchedAccessToken && !mediaInfoError && !fetchedConnectionType) || !webrtcLib) && (
@@ -310,4 +373,4 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
         />
     </div>
   );
-}; 
+};

--- a/src/components/features/piko/piko-video-player.tsx
+++ b/src/components/features/piko/piko-video-player.tsx
@@ -15,6 +15,9 @@ import type {
   ConnectionError as ConnectionErrorType,
 } from '@networkoptix/webrtc-stream-manager';
 
+// Stats sampling interval for fallback path (ms)
+const STATS_UPDATE_INTERVAL_MS = 800;
+
 interface WebRTCConnectionDetails {
   pikoSystemId?: string;
   accessToken: string;
@@ -325,7 +328,7 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
       const frames = quality?.totalVideoFrames ?? 0;
       const now = performance.now();
       const dt = now - lastTime;
-      if (dt >= 800 && onStats) {
+      if (dt >= STATS_UPDATE_INTERVAL_MS && onStats) {
         const fps = Math.max(0, ((frames - lastFrames) * 1000) / dt);
         const vw = (video as HTMLVideoElement).videoWidth;
         const vh = (video as HTMLVideoElement).videoHeight;

--- a/src/components/features/play/PlayLayoutControls.tsx
+++ b/src/components/features/play/PlayLayoutControls.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectSeparator } from '@/components/ui/select';
+import { Select, SelectContent, SelectTrigger, SelectValue, SelectSeparator } from '@/components/ui/select';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { MoreHorizontal, Save, LayoutTemplate, Plus, Pencil, Trash2, SlidersHorizontal, Pin } from 'lucide-react';
+import { MoreHorizontal, Save, LayoutTemplate, Plus, Pencil, Trash2, SlidersHorizontal, Pin, Check } from 'lucide-react';
 
 export interface LayoutOption {
 	id: string;
@@ -42,6 +43,12 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 
 	const canSave = useMemo(() => activeLayoutId !== 'auto', [activeLayoutId]);
 
+	const activeLabel = useMemo(() => {
+		if (activeLayoutId === 'auto') return 'Auto';
+		const found = layouts.find(l => l.id === activeLayoutId);
+		return found?.name ?? 'Select layout';
+	}, [activeLayoutId, layouts]);
+
 	const handleSelectChange = (v: string) => {
 		if (v === '__new__') {
 			setPendingName('');
@@ -60,27 +67,53 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 			<div className="inline-flex items-center gap-2 rounded-md bg-background/80 backdrop-blur-sm border px-1.5 py-1">
 				<LayoutTemplate className="h-4 w-4 text-muted-foreground" />
 				<Select value={activeLayoutId} onValueChange={handleSelectChange}>
-					<SelectTrigger className="h-8 w-[200px]">
-						<SelectValue placeholder="Select layout" />
+					<SelectTrigger className="h-8 w-[200px] min-w-0">
+						<div className="min-w-0 truncate">
+							<span className="truncate">{activeLabel}</span>
+						</div>
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="__new__">
-							<span className="inline-flex items-center"><Plus className="mr-2 h-4 w-4" /> New layout…</span>
-						</SelectItem>
-						<SelectSeparator />
-						<SelectItem value="auto">
-							<span className="inline-flex items-center">
-								<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === null ? '' : 'invisible'}`} />
-								<span>Auto</span>
+						{/* New layout item with icon that won't mirror into trigger */}
+						<SelectPrimitive.Item
+							value="__new__"
+							className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground"
+						>
+							<span className="mr-2 inline-flex items-center justify-center"><Plus className="h-4 w-4" /></span>
+							<SelectPrimitive.ItemText className="truncate">New layout…</SelectPrimitive.ItemText>
+							<span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+								<SelectPrimitive.ItemIndicator>
+									<Check className="h-4 w-4" />
+								</SelectPrimitive.ItemIndicator>
 							</span>
-						</SelectItem>
+						</SelectPrimitive.Item>
+						<SelectSeparator />
+						{/* Auto item with pin icon, not mirrored in trigger */}
+						<SelectPrimitive.Item
+							value="auto"
+							className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground"
+						>
+							<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === null ? '' : 'invisible'}`} />
+							<SelectPrimitive.ItemText className="truncate">Auto</SelectPrimitive.ItemText>
+							<span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+								<SelectPrimitive.ItemIndicator>
+									<Check className="h-4 w-4" />
+								</SelectPrimitive.ItemIndicator>
+							</span>
+						</SelectPrimitive.Item>
 						{orderedLayouts.map(l => (
-							<SelectItem key={l.id} value={l.id}>
-								<span className="inline-flex items-center">
-									<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === l.id ? '' : 'invisible'}`} />
-									<span>{l.name}</span>
+							<SelectPrimitive.Item
+								key={l.id}
+								value={l.id}
+								className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground"
+							>
+								<Pin className={`mr-2 h-3.5 w-3.5 text-muted-foreground ${defaultLayoutId === l.id ? '' : 'invisible'}`} />
+								<SelectPrimitive.ItemText className="truncate">{l.name}</SelectPrimitive.ItemText>
+								<span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+									<SelectPrimitive.ItemIndicator>
+										<Check className="h-4 w-4" />
+									</SelectPrimitive.ItemIndicator>
 								</span>
-							</SelectItem>
+							</SelectPrimitive.Item>
 						))}
 					</SelectContent>
 				</Select>
@@ -101,7 +134,7 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 							<MoreHorizontal className="h-4 w-4" />
 						</Button>
 					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
+                    <DropdownMenuContent align="end">
 						<DropdownMenuItem
 						onSelect={() => { onSetDefault?.(activeLayoutId); }}
 						>
@@ -173,23 +206,26 @@ export const PlayLayoutControls: React.FC<PlayLayoutControlsProps> = ({
 
 			<Dialog open={isRenameOpen} onOpenChange={setIsRenameOpen}>
 				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Rename Layout</DialogTitle>
-					</DialogHeader>
-					<Input placeholder="Layout name" value={pendingName} onChange={(e) => setPendingName(e.target.value)} />
-					<DialogFooter>
-						<Button variant="secondary" onClick={() => setIsRenameOpen(false)}>Cancel</Button>
-						<Button
-							onClick={() => {
-								if (pendingName.trim() && renameTargetId) {
-									onRename(renameTargetId, pendingName.trim());
-									setIsRenameOpen(false);
-								}
-							}}
-						>
-							Save
-						</Button>
-					</DialogFooter>
+					<form
+						className="grid gap-4"
+						onSubmit={(e) => {
+							e.preventDefault();
+							const name = pendingName.trim();
+							if (name && renameTargetId) {
+								onRename(renameTargetId, name);
+								setIsRenameOpen(false);
+							}
+						}}
+					>
+						<DialogHeader>
+							<DialogTitle>Rename Layout</DialogTitle>
+						</DialogHeader>
+						<Input placeholder="Layout name" value={pendingName} onChange={(e) => setPendingName(e.target.value)} />
+						<DialogFooter>
+							<Button type="button" variant="secondary" onClick={() => setIsRenameOpen(false)}>Cancel</Button>
+							<Button type="submit" disabled={!pendingName.trim() || !renameTargetId}>Save</Button>
+						</DialogFooter>
+					</form>
 				</DialogContent>
 			</Dialog>
 

--- a/src/components/features/play/play-grid.tsx
+++ b/src/components/features/play/play-grid.tsx
@@ -149,98 +149,8 @@ export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, ini
 				})();
 				return (
 				<div key={device.id} className="overflow-hidden grid-item-container">
-					{overlayHeaders ? (<Card className="h-full w-full flex flex-col overflow-hidden rounded-lg">
-						<CardContent className="p-0 grow relative">
-							<div className="absolute inset-0">
-                                <PikoVideoPlayer
-										connectorId={device.connectorId}
-										cameraId={device.deviceId}
-										className="w-full h-full"
-                                    enableStats={showInfo}
-                                    onStats={showInfo ? ({ fps, width, height }) => {
-                                        smoothAndThrottleFps(device.id, fps);
-                                        if (width && height) {
-                                            setResolutionById(prev => {
-                                                const cur = prev[device.id];
-                                                if (cur && cur.w === width && cur.h === height) return prev;
-                                                return { ...prev, [device.id]: { w: width, h: height } };
-                                            });
-                                        }
-                                    } : undefined}
-									/>
-							</div>
-
-							{/* Top overlay with gradient and actions */}
-							<div className="absolute inset-x-0 top-0">
-								{/* Single feathered gradient to avoid a hard edge while staying subtle */}
-								<div
-									className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-[linear-gradient(to_bottom,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0.38)_38%,rgba(0,0,0,0.14)_78%,rgba(0,0,0,0)_100%)] backdrop-blur-[2px] z-0"
-									aria-hidden="true"
-								/>
-								<div className="relative z-20 px-2 py-1 flex items-center justify-between gap-2 text-white">
-									<div className="min-w-0 flex items-center gap-1.5 text-xs">
-										<Cctv className="h-3.5 w-3.5 text-white/80" />
-										<span className="truncate">{device.name}</span>
-										{resolvedSpaceName ? (
-											<>
-												<span className="text-white/60">•</span>
-												<span className="inline-flex items-center gap-1 truncate text-white/80">
-													<Box className="h-3.5 w-3.5" />
-													<span className="truncate">{resolvedSpaceName}</span>
-												</span>
-											</>
-										) : null}
-										{resolvedLocationName ? (
-											<>
-												<span className="text-white/60">•</span>
-												<span className="inline-flex items-center gap-1 truncate text-white/80">
-													<Building className="h-3.5 w-3.5" />
-													<span className="truncate">{resolvedLocationName}</span>
-												</span>
-											</>
-										) : null}
-									</div>
-
-									{onRemoveFromLayout ? (
-										<DropdownMenu>
-											<DropdownMenuTrigger asChild>
-												<Button
-													variant="ghost"
-													size="sm"
-													className="h-7 w-7 p-0 no-drag text-white/90 hover:text-white hover:bg-white/10"
-													aria-label="Tile options"
-												>
-													<MoreHorizontal className="h-4 w-4" />
-												</Button>
-											</DropdownMenuTrigger>
-												<DropdownMenuContent align="end" className="no-drag">
-													<DropdownMenuItem
-														className="text-destructive focus:text-destructive"
-														onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemoveFromLayout(device.id); }}
-													>
-														<Trash2 className="mr-2 h-4 w-4" />
-														Remove
-													</DropdownMenuItem>
-												</DropdownMenuContent>
-										</DropdownMenu>
-									) : null}
-								</div>
-						</div>
-                            {showInfo ? (
-                                <div className="absolute bottom-1 right-1 z-20">
-                                    <span className="block px-1.5 py-1 rounded text-[10px] leading-tight bg-black/55 text-white select-none font-mono text-right">
-                                        {(() => {
-                                            const res = resolutionById[device.id];
-                                            return res && res.w && res.h ? `${res.w}×${res.h}` : '—×—';
-                                        })()}
-                                        <br />
-                                        {typeof fpsById[device.id] === 'number' ? `${fpsById[device.id].toFixed(1)} fps` : '— fps'}
-                                    </span>
-                                </div>
-                            ) : null}
-						</CardContent>
-					</Card>) : (
-						<Card className="h-full w-full flex flex-col">
+					<Card className="h-full w-full flex flex-col overflow-hidden rounded-lg">
+						{!overlayHeaders ? (
 							<CardHeader className="px-2 py-1.5 shrink-0 bg-black text-white rounded-t-lg">
 								<div className="flex items-center justify-between gap-2">
 									<div className="min-w-0">
@@ -287,40 +197,97 @@ export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, ini
 									) : null}
 								</div>
 							</CardHeader>
-							<CardContent className="p-0 grow relative overflow-hidden rounded-b-lg">
-                                <div className="absolute inset-0">
-                                <PikoVideoPlayer
-                                            connectorId={device.connectorId}
-                                            cameraId={device.deviceId}
-                                            className="w-full h-full"
-                                            enableStats={showInfo}
-                                            onStats={showInfo ? ({ fps, width, height }) => {
-                                                smoothAndThrottleFps(device.id, fps);
-                                                if (width && height) {
-                                                    setResolutionById(prev => {
-                                                        const cur = prev[device.id];
-                                                        if (cur && cur.w === width && cur.h === height) return prev;
-                                                        return { ...prev, [device.id]: { w: width, h: height } };
-                                                    });
-                                                }
-                                            } : undefined}
-                                        />
-                                </div>
-                                {showInfo ? (
-                                    <div className="absolute bottom-1 right-1 z-20">
-                                        <span className="block px-1.5 py-1 rounded text-[10px] leading-tight bg-black/55 text-white select-none font-mono text-right">
-                                            {(() => {
-                                                const res = resolutionById[device.id];
-                                                return res && res.w && res.h ? `${res.w}×${res.h}` : '—×—';
-                                            })()}
-                                            <br />
-                                            {typeof fpsById[device.id] === 'number' ? `${fpsById[device.id].toFixed(1)} fps` : '— fps'}
-                                        </span>
-                                    </div>
-                                ) : null}
-							</CardContent>
-						</Card>
-					)}
+						) : null}
+						<CardContent className="p-0 grow relative overflow-hidden rounded-b-lg">
+							<div className="absolute inset-0">
+								<PikoVideoPlayer
+										connectorId={device.connectorId}
+										cameraId={device.deviceId}
+										className="w-full h-full"
+										enableStats={showInfo}
+										onStats={showInfo ? ({ fps, width, height }) => {
+												smoothAndThrottleFps(device.id, fps);
+												if (width && height) {
+													setResolutionById(prev => {
+														const cur = prev[device.id];
+														if (cur && cur.w === width && cur.h === height) return prev;
+														return { ...prev, [device.id]: { w: width, h: height } };
+													});
+												}
+										} : undefined}
+									/>
+							</div>
+
+							{overlayHeaders ? (
+								<div className="absolute inset-x-0 top-0">
+									<div
+										className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-[linear-gradient(to_bottom,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0.38)_38%,rgba(0,0,0,0.14)_78%,rgba(0,0,0,0)_100%)] backdrop-blur-[2px] z-0"
+										aria-hidden="true"
+									/>
+									<div className="relative z-20 px-2 py-1 flex items-center justify-between gap-2 text-white">
+										<div className="min-w-0 flex items-center gap-1.5 text-xs">
+											<Cctv className="h-3.5 w-3.5 text-white/80" />
+											<span className="truncate">{device.name}</span>
+											{resolvedSpaceName ? (
+												<>
+													<span className="text-white/60">•</span>
+													<span className="inline-flex items-center gap-1 truncate text-white/80">
+														<Box className="h-3.5 w-3.5" />
+														<span className="truncate">{resolvedSpaceName}</span>
+													</span>
+												</>
+											) : null}
+											{resolvedLocationName ? (
+												<>
+													<span className="text-white/60">•</span>
+													<span className="inline-flex items-center gap-1 truncate text-white/80">
+														<Building className="h-3.5 w-3.5" />
+														<span className="truncate">{resolvedLocationName}</span>
+													</span>
+												</>
+											) : null}
+										</div>
+										{onRemoveFromLayout ? (
+											<DropdownMenu>
+												<DropdownMenuTrigger asChild>
+													<Button
+														variant="ghost"
+														size="sm"
+														className="h-7 w-7 p-0 no-drag text-white/90 hover:text-white hover:bg-white/10"
+														aria-label="Tile options"
+													>
+														<MoreHorizontal className="h-4 w-4" />
+													</Button>
+												</DropdownMenuTrigger>
+													<DropdownMenuContent align="end" className="no-drag">
+														<DropdownMenuItem
+															className="text-destructive focus:text-destructive"
+															onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemoveFromLayout(device.id); }}
+														>
+															<Trash2 className="mr-2 h-4 w-4" />
+															Remove
+														</DropdownMenuItem>
+													</DropdownMenuContent>
+											</DropdownMenu>
+										) : null}
+									</div>
+								</div>
+							) : null}
+
+							{showInfo ? (
+								<div className="absolute bottom-1 right-1 z-20">
+									<span className="block px-1.5 py-1 rounded text-[10px] leading-tight bg-black/55 text-white select-none font-mono text-right">
+										{(() => {
+											const res = resolutionById[device.id];
+											return res && res.w && res.h ? `${res.w}×${res.h}` : '—×—';
+										})()}
+										<br />
+										{typeof fpsById[device.id] === 'number' ? `${fpsById[device.id].toFixed(1)} fps` : '— fps'}
+									</span>
+								</div>
+							) : null}
+						</CardContent>
+					</Card>
 				</div>
 				);
 			})}

--- a/src/components/features/play/play-grid.tsx
+++ b/src/components/features/play/play-grid.tsx
@@ -19,12 +19,35 @@ export interface PlayGridProps {
   onAddCameras?: () => void;
   spaces: Space[];
   locations: Location[];
+  overlayHeaders?: boolean;
+  showInfo?: boolean;
 }
 
-export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, initialLayoutItems, onRemoveFromLayout, onAddCameras, spaces, locations }) => {
+export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, initialLayoutItems, onRemoveFromLayout, onAddCameras, spaces, locations, overlayHeaders = true, showInfo = false }) => {
 	const playableDevices = useMemo(() => devices.filter(d => d.deviceId && d.connectorId), [devices]);
 
     const [layout, setLayout] = useState<Layout[]>([]);
+    const [fpsById, setFpsById] = useState<Record<string, number>>({});
+    const [resolutionById, setResolutionById] = useState<Record<string, { w: number; h: number }>>({});
+    const lastFpsUpdateAtRef = React.useRef<Record<string, number>>({});
+    const smoothAndThrottleFps = React.useCallback((deviceId: string, nextFps: number) => {
+        const now = performance.now();
+        const lastAt = lastFpsUpdateAtRef.current[deviceId] ?? 0;
+        // Throttle UI updates to ~4/sec
+        if (now - lastAt < 250) return;
+        setFpsById(prev => {
+            const prevFps = prev[deviceId];
+            // Exponential smoothing
+            const alpha = 0.2;
+            const base = typeof prevFps === 'number' ? prevFps : nextFps;
+            const smoothedFloat = base + alpha * (nextFps - base);
+            // Round to one decimal place for visible, gentle movement
+            const smoothed = Math.round(smoothedFloat * 10) / 10;
+            if (typeof prevFps === 'number' && Math.abs(smoothed - prevFps) < 0.05) return prev;
+            lastFpsUpdateAtRef.current[deviceId] = now;
+            return { ...prev, [deviceId]: smoothed };
+        });
+    }, []);
 
 	// Single, fluid 12-column grid
 	const COLS = 12;
@@ -126,64 +149,178 @@ export const PlayGrid: React.FC<PlayGridProps> = ({ devices, onLayoutChange, ini
 				})();
 				return (
 				<div key={device.id} className="overflow-hidden grid-item-container">
-					<Card className="h-full w-full flex flex-col">
-					<CardHeader className="px-2 py-1.5 shrink-0 bg-black text-white rounded-t-lg">
-						<div className="flex items-center justify-between gap-2">
-								<div className="min-w-0">
-								<CardTitle className="text-xs font-medium leading-tight truncate flex items-center gap-1.5" title={device.name}>
-									<Cctv className="h-3.5 w-3.5 text-muted-foreground" />
-									<span className="truncate">{device.name}</span>
-									{resolvedSpaceName ? (
-										<>
-											<span className="text-muted-foreground">•</span>
-											<span className="inline-flex items-center gap-1 truncate text-muted-foreground">
-												<Box className="h-3.5 w-3.5" />
-												<span className="truncate">{resolvedSpaceName}</span>
-											</span>
-										</>
-									) : null}
-									{resolvedLocationName ? (
-										<>
-											<span className="text-muted-foreground">•</span>
-											<span className="inline-flex items-center gap-1 truncate text-muted-foreground">
-												<Building className="h-3.5 w-3.5" />
-												<span className="truncate">{resolvedLocationName}</span>
-											</span>
-										</>
-									) : null}
-								</CardTitle>
+					{overlayHeaders ? (<Card className="h-full w-full flex flex-col overflow-hidden rounded-lg">
+						<CardContent className="p-0 grow relative">
+							<div className="absolute inset-0">
+                                <PikoVideoPlayer
+										connectorId={device.connectorId}
+										cameraId={device.deviceId}
+										className="w-full h-full"
+                                    enableStats={showInfo}
+                                    onStats={showInfo ? ({ fps, width, height }) => {
+                                        smoothAndThrottleFps(device.id, fps);
+                                        if (width && height) {
+                                            setResolutionById(prev => {
+                                                const cur = prev[device.id];
+                                                if (cur && cur.w === width && cur.h === height) return prev;
+                                                return { ...prev, [device.id]: { w: width, h: height } };
+                                            });
+                                        }
+                                    } : undefined}
+									/>
 							</div>
-								{onRemoveFromLayout ? (
-									<DropdownMenu>
-										<DropdownMenuTrigger asChild>
-											<Button variant="ghost" size="sm" className="h-7 w-7 p-0 no-drag" aria-label="Tile options">
-												<MoreHorizontal className="h-4 w-4" />
-											</Button>
-										</DropdownMenuTrigger>
-											<DropdownMenuContent align="end" className="no-drag">
-                                            
-											<DropdownMenuItem
-												className="text-destructive focus:text-destructive"
-												onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemoveFromLayout(device.id); }}
-											>
-												<Trash2 className="mr-2 h-4 w-4" />
-												Remove
-											</DropdownMenuItem>
-										</DropdownMenuContent>
-									</DropdownMenu>
-								) : null}
+
+							{/* Top overlay with gradient and actions */}
+							<div className="absolute inset-x-0 top-0">
+								{/* Single feathered gradient to avoid a hard edge while staying subtle */}
+								<div
+									className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-[linear-gradient(to_bottom,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0.38)_38%,rgba(0,0,0,0.14)_78%,rgba(0,0,0,0)_100%)] backdrop-blur-[2px] z-0"
+									aria-hidden="true"
+								/>
+								<div className="relative z-20 px-2 py-1 flex items-center justify-between gap-2 text-white">
+									<div className="min-w-0 flex items-center gap-1.5 text-xs">
+										<Cctv className="h-3.5 w-3.5 text-white/80" />
+										<span className="truncate">{device.name}</span>
+										{resolvedSpaceName ? (
+											<>
+												<span className="text-white/60">•</span>
+												<span className="inline-flex items-center gap-1 truncate text-white/80">
+													<Box className="h-3.5 w-3.5" />
+													<span className="truncate">{resolvedSpaceName}</span>
+												</span>
+											</>
+										) : null}
+										{resolvedLocationName ? (
+											<>
+												<span className="text-white/60">•</span>
+												<span className="inline-flex items-center gap-1 truncate text-white/80">
+													<Building className="h-3.5 w-3.5" />
+													<span className="truncate">{resolvedLocationName}</span>
+												</span>
+											</>
+										) : null}
+									</div>
+
+									{onRemoveFromLayout ? (
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button
+													variant="ghost"
+													size="sm"
+													className="h-7 w-7 p-0 no-drag text-white/90 hover:text-white hover:bg-white/10"
+													aria-label="Tile options"
+												>
+													<MoreHorizontal className="h-4 w-4" />
+												</Button>
+											</DropdownMenuTrigger>
+												<DropdownMenuContent align="end" className="no-drag">
+													<DropdownMenuItem
+														className="text-destructive focus:text-destructive"
+														onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemoveFromLayout(device.id); }}
+													>
+														<Trash2 className="mr-2 h-4 w-4" />
+														Remove
+													</DropdownMenuItem>
+												</DropdownMenuContent>
+										</DropdownMenu>
+									) : null}
+								</div>
 						</div>
-						</CardHeader>
-                            <CardContent className="p-0 grow relative overflow-hidden rounded-b-lg">
+                            {showInfo ? (
+                                <div className="absolute bottom-1 right-1 z-20">
+                                    <span className="block px-1.5 py-1 rounded text-[10px] leading-tight bg-black/55 text-white select-none font-mono text-right">
+                                        {(() => {
+                                            const res = resolutionById[device.id];
+                                            return res && res.w && res.h ? `${res.w}×${res.h}` : '—×—';
+                                        })()}
+                                        <br />
+                                        {typeof fpsById[device.id] === 'number' ? `${fpsById[device.id].toFixed(1)} fps` : '— fps'}
+                                    </span>
+                                </div>
+                            ) : null}
+						</CardContent>
+					</Card>) : (
+						<Card className="h-full w-full flex flex-col">
+							<CardHeader className="px-2 py-1.5 shrink-0 bg-black text-white rounded-t-lg">
+								<div className="flex items-center justify-between gap-2">
+									<div className="min-w-0">
+										<CardTitle className="text-xs font-medium leading-tight truncate flex items-center gap-1.5" title={device.name}>
+											<Cctv className="h-3.5 w-3.5 text-muted-foreground" />
+											<span className="truncate">{device.name}</span>
+											{resolvedSpaceName ? (
+												<>
+													<span className="text-muted-foreground">•</span>
+													<span className="inline-flex items-center gap-1 truncate text-muted-foreground">
+														<Box className="h-3.5 w-3.5" />
+														<span className="truncate">{resolvedSpaceName}</span>
+													</span>
+												</>
+											) : null}
+											{resolvedLocationName ? (
+												<>
+													<span className="text-muted-foreground">•</span>
+													<span className="inline-flex items-center gap-1 truncate text-muted-foreground">
+														<Building className="h-3.5 w-3.5" />
+														<span className="truncate">{resolvedLocationName}</span>
+													</span>
+												</>
+											) : null}
+										</CardTitle>
+									</div>
+									{onRemoveFromLayout ? (
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button variant="ghost" size="sm" className="h-7 w-7 p-0 no-drag" aria-label="Tile options">
+													<MoreHorizontal className="h-4 w-4" />
+												</Button>
+											</DropdownMenuTrigger>
+												<DropdownMenuContent align="end" className="no-drag">
+													<DropdownMenuItem
+														className="text-destructive focus:text-destructive"
+														onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemoveFromLayout(device.id); }}
+													>
+														<Trash2 className="mr-2 h-4 w-4" />
+														Remove
+													</DropdownMenuItem>
+												</DropdownMenuContent>
+										</DropdownMenu>
+									) : null}
+								</div>
+							</CardHeader>
+							<CardContent className="p-0 grow relative overflow-hidden rounded-b-lg">
                                 <div className="absolute inset-0">
-                                        <PikoVideoPlayer
+                                <PikoVideoPlayer
                                             connectorId={device.connectorId}
                                             cameraId={device.deviceId}
                                             className="w-full h-full"
+                                            enableStats={showInfo}
+                                            onStats={showInfo ? ({ fps, width, height }) => {
+                                                smoothAndThrottleFps(device.id, fps);
+                                                if (width && height) {
+                                                    setResolutionById(prev => {
+                                                        const cur = prev[device.id];
+                                                        if (cur && cur.w === width && cur.h === height) return prev;
+                                                        return { ...prev, [device.id]: { w: width, h: height } };
+                                                    });
+                                                }
+                                            } : undefined}
                                         />
                                 </div>
-                            </CardContent>
-					</Card>
+                                {showInfo ? (
+                                    <div className="absolute bottom-1 right-1 z-20">
+                                        <span className="block px-1.5 py-1 rounded text-[10px] leading-tight bg-black/55 text-white select-none font-mono text-right">
+                                            {(() => {
+                                                const res = resolutionById[device.id];
+                                                return res && res.w && res.h ? `${res.w}×${res.h}` : '—×—';
+                                            })()}
+                                            <br />
+                                            {typeof fpsById[device.id] === 'number' ? `${fpsById[device.id].toFixed(1)} fps` : '— fps'}
+                                        </span>
+                                    </div>
+                                ) : null}
+							</CardContent>
+						</Card>
+					)}
 				</div>
 				);
 			})}


### PR DESCRIPTION
This pull request adds a new "View Settings" dialog to the Play page, allowing users to toggle video overlay headers and info display, and introduces FPS/resolution statistics collection for video streams. It also improves the Play Layout selection UI for clarity and accessibility, and refactors layout renaming to use a form for better UX. The most important changes are grouped below.

**Play Page: View Settings & State Management**
* Added a "View Settings" dialog accessible from a new settings button, enabling users to toggle overlay headers and info display. State is persisted in `localStorage` and passed to the `PlayGrid` component. [[1]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R47-R58) [[2]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R371-R386) [[3]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R451-R488) [[4]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R532-R533) [[5]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R565-R566)

**Video Stats Collection**
* Implemented FPS and resolution statistics collection in `PikoVideoPlayer`, supporting both modern and legacy browsers, with throttled updates and a callback for the parent component to consume stats. [[1]](diffhunk://#diff-f84c6567abbc64552ac5c47be49d9ea81e84f33851f5d0d4c1bb12b1c7fe27e7R24-R34) [[2]](diffhunk://#diff-f84c6567abbc64552ac5c47be49d9ea81e84f33851f5d0d4c1bb12b1c7fe27e7L39-R45) [[3]](diffhunk://#diff-f84c6567abbc64552ac5c47be49d9ea81e84f33851f5d0d4c1bb12b1c7fe27e7R65-R66) [[4]](diffhunk://#diff-f84c6567abbc64552ac5c47be49d9ea81e84f33851f5d0d4c1bb12b1c7fe27e7R285-R339) [[5]](diffhunk://#diff-8e1129904c22ddabb69885490846f4df8bd068a021fa761d4c7e1bab5ace2b77R22-R50)

**Play Layout Selection UI**
* Improved the Play Layout dropdown by using Radix primitives for custom rendering, better truncation, and clearer selection indicators for "Auto" and "New layout" options. [[1]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009R4-R11) [[2]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009R46-R51) [[3]](diffhunk://#diff-fbed26c2a6371a450fe0c8d5e0cce80b3770254ccc5872f93599d9308dc15009L63-R116)

**Layout Renaming UX**
* Refactored the layout renaming dialog to use a form with validation and a submit button, improving accessibility and preventing accidental renames.