### PR TITLE
Add device renaming support for Piko and Genea

### DIFF
--- a/src/app/api/devices/[internalDeviceId]/name/route.ts
+++ b/src/app/api/devices/[internalDeviceId]/name/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withOrganizationAuth, type OrganizationAuthContext } from '@/lib/auth/withOrganizationAuth';
+import type { RouteContext } from '@/lib/auth/withApiRouteAuth';
+import { db } from '@/data/db';
+import { devices as devicesTable } from '@/data/db/schema';
+import { eq } from 'drizzle-orm';
+import { requestDeviceRename } from '@/lib/device-actions';
+
+type PatchBody = { name?: string };
+
+export const PATCH = withOrganizationAuth(async (
+  request: NextRequest,
+  authContext: OrganizationAuthContext,
+  context: RouteContext<{ internalDeviceId: string }>
+) => {
+  try {
+    if (!context?.params) {
+      return NextResponse.json({ success: false, error: 'Missing route parameters' }, { status: 400 });
+    }
+    const { internalDeviceId } = await context.params;
+
+    let body: PatchBody;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const rawName = (body.name ?? '').toString();
+    const name = rawName.trim();
+    if (!name) {
+      return NextResponse.json({ success: false, error: 'Name is required' }, { status: 400 });
+    }
+    if (name.length > 100) {
+      return NextResponse.json({ success: false, error: 'Name is too long (max 100)' }, { status: 400 });
+    }
+
+    // Use the device actions service layer for all the heavy lifting
+    await requestDeviceRename(internalDeviceId, name);
+
+    try {
+      await db.update(devicesTable)
+        .set({ name, updatedAt: new Date() })
+        .where(eq(devicesTable.id, internalDeviceId));
+    } catch (e) {
+      // Do not fail the request if local update fails after remote success
+      console.error(`[API Device Rename] Failed to update local DB for ${internalDeviceId}:`, e);
+    }
+
+    return NextResponse.json({ success: true, data: { name } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+});
+
+
+
+

--- a/src/components/features/devices/device-detail-dialog-content.tsx
+++ b/src/components/features/devices/device-detail-dialog-content.tsx
@@ -290,8 +290,9 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
                       autoFocus
                       onChange={(e) => setTempName(e.target.value)}
                       onKeyDown={async (e) => {
+                        const trimmedName = tempName.trim();
                         if (e.key === 'Enter') {
-                          const ok = await renameDevice(device.internalId, tempName.trim());
+                          const ok = await renameDevice(device.internalId, trimmedName);
                           if (ok) setIsEditingName(false);
                         } else if (e.key === 'Escape') {
                           setIsEditingName(false);
@@ -299,8 +300,9 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
                         }
                       }}
                       onBlur={async () => {
-                        if (tempName.trim() && tempName.trim() !== (actualDevice?.name ?? device.name)) {
-                          await renameDevice(device.internalId, tempName.trim());
+                        const trimmedName = tempName.trim();
+                        if (trimmedName && trimmedName !== (actualDevice?.name ?? device.name)) {
+                          await renameDevice(device.internalId, trimmedName);
                         }
                         setIsEditingName(false);
                       }}

--- a/src/components/features/devices/device-detail-dialog-content.tsx
+++ b/src/components/features/devices/device-detail-dialog-content.tsx
@@ -302,9 +302,15 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
                       onBlur={async () => {
                         const trimmedName = tempName.trim();
                         if (trimmedName && trimmedName !== (actualDevice?.name ?? device.name)) {
-                          await renameDevice(device.internalId, trimmedName);
+                          const ok = await renameDevice(device.internalId, trimmedName);
+                          if (ok) {
+                            setIsEditingName(false);
+                          } else {
+                            toast.error('Failed to rename device. Please try again.');
+                          }
+                        } else {
+                          setIsEditingName(false);
                         }
-                        setIsEditingName(false);
                       }}
                       disabled={isRenaming}
                     />

--- a/src/components/features/devices/device-detail-dialog-content.tsx
+++ b/src/components/features/devices/device-detail-dialog-content.tsx
@@ -306,7 +306,7 @@ export const DeviceDetailDialogContent: React.FC<DeviceDetailDialogContentProps>
                           if (ok) {
                             setIsEditingName(false);
                           } else {
-                            toast.error('Failed to rename device. Please try again.');
+                            // Keep edit mode; error toast already shown by store
                           }
                         } else {
                           setIsEditingName(false);

--- a/src/lib/device-actions/capabilities.ts
+++ b/src/lib/device-actions/capabilities.ts
@@ -150,4 +150,24 @@ export function getOnOffActionsForOption(option: DeviceOptionLike): ActionableSt
   return getOnOffActions(connectorCategory, inferredType);
 }
 
+/**
+ * Central registry of which connector categories support device renaming.
+ */
+export const RENAMEABLE_CONNECTOR_CATEGORIES = ['piko', 'genea'] as const;
+
+/**
+ * Returns true if the connector category supports device renaming.
+ */
+export function isRenameSupported(connectorCategory: string | undefined | null): boolean {
+  if (!connectorCategory) return false;
+  return RENAMEABLE_CONNECTOR_CATEGORIES.includes(connectorCategory as any);
+}
+
+/**
+ * UI helper: returns true if the device option resolves to a renameable device.
+ */
+export function isRenameableOption(option: DeviceOptionLike): boolean {
+  return isRenameSupported(option.connectorCategory);
+}
+
 

--- a/src/lib/device-actions/index.ts
+++ b/src/lib/device-actions/index.ts
@@ -2,10 +2,8 @@ import { db } from '@/data/db';
 import { devices, connectors } from '@/data/db/schema';
 import { eq } from 'drizzle-orm';
 import { ActionableState, DeviceCommand } from '../mappings/definitions';
-import * as yolinkDriver from '@/services/drivers/yolink';
-import type { YoLinkConfig } from '@/services/drivers/yolink';
 import { renamePikoDevice } from '@/services/drivers/piko';
-import type { GeneaDoorUpdatePayload } from '@/services/drivers/genea';
+import type { GeneaDoorUpdatePayload, GeneaDoor } from '@/services/drivers/genea';
 import { isRenameSupported } from './capabilities';
 // Import other driver types as needed, e.g.:
 // import type { PikoConfig } from '@/services/drivers/piko'; 
@@ -299,7 +297,7 @@ export async function requestDeviceRename(
             const payload: GeneaDoorUpdatePayload = { name: newName };
             
             if (device.rawDeviceData && typeof device.rawDeviceData === 'object') {
-                const rawData = device.rawDeviceData as any;
+                const rawData = device.rawDeviceData as Partial<GeneaDoor>;
                 if (typeof rawData.is_elevator_door === 'boolean') {
                     payload.is_elevator_door = rawData.is_elevator_door;
                 }

--- a/src/lib/device-actions/index.ts
+++ b/src/lib/device-actions/index.ts
@@ -5,6 +5,7 @@ import { ActionableState, DeviceCommand } from '../mappings/definitions';
 import * as yolinkDriver from '@/services/drivers/yolink';
 import type { YoLinkConfig } from '@/services/drivers/yolink';
 import { renamePikoDevice } from '@/services/drivers/piko';
+import type { GeneaDoorUpdatePayload } from '@/services/drivers/genea';
 import { isRenameSupported } from './capabilities';
 // Import other driver types as needed, e.g.:
 // import type { PikoConfig } from '@/services/drivers/piko'; 
@@ -295,7 +296,7 @@ export async function requestDeviceRename(
             
             // For Genea, we need to provide is_elevator_door from the current device data
             // since the API requires it even for name-only updates
-            const payload: any = { name: newName };
+            const payload: GeneaDoorUpdatePayload = { name: newName };
             
             if (device.rawDeviceData && typeof device.rawDeviceData === 'object') {
                 const rawData = device.rawDeviceData as any;

--- a/src/lib/device-actions/index.ts
+++ b/src/lib/device-actions/index.ts
@@ -4,6 +4,8 @@ import { eq } from 'drizzle-orm';
 import { ActionableState, DeviceCommand } from '../mappings/definitions';
 import * as yolinkDriver from '@/services/drivers/yolink';
 import type { YoLinkConfig } from '@/services/drivers/yolink';
+import { renamePikoDevice } from '@/services/drivers/piko';
+import { isRenameSupported } from './capabilities';
 // Import other driver types as needed, e.g.:
 // import type { PikoConfig } from '@/services/drivers/piko'; 
 // import type { GeneaConfig } from '@/services/drivers/genea';
@@ -214,6 +216,109 @@ export async function requestDeviceCommand(
             throw error; 
         } else {
             throw new Error('An unknown error occurred while executing device command.');
+        }
+    }
+}
+
+/**
+ * Attempts to rename a device via its connector driver.
+ * This acts as an abstraction layer over different vendor APIs.
+ * 
+ * @param internalDeviceId The internal database ID of the device record.
+ * @param newName The new name for the device.
+ * @returns Promise resolving to true if the rename was successful.
+ * @throws Error for configuration issues, unsupported devices, or driver errors.
+ */
+export async function requestDeviceRename(
+    internalDeviceId: string, 
+    newName: string
+): Promise<boolean> {
+    console.log(`[DeviceActions] Requesting rename for internal device ID ${internalDeviceId} to "${newName}"`);
+
+    try {
+        // 1. Fetch Device Info using the same pattern
+        const device = await db.query.devices.findFirst({
+            where: eq(devices.id, internalDeviceId),
+            columns: {
+                id: true,
+                deviceId: true,
+                connectorId: true,
+                rawDeviceData: true, // Need this for Genea to get current is_elevator_door value
+            }
+        });
+
+        if (!device) {
+            console.error(`[DeviceActions] Device with internal ID ${internalDeviceId} not found.`);
+            throw new Error(`Device not found.`);
+        }
+
+        console.log(`[DeviceActions] Found device: ${device.deviceId}`);
+
+        // 2. Fetch Connector Info & Config using the same pattern
+        const connector = await db.query.connectors.findFirst({
+            where: eq(connectors.id, device.connectorId),
+            columns: {
+                id: true,
+                category: true,
+                cfg_enc: true,
+            }
+        });
+
+        if (!connector) {
+            console.error(`[DeviceActions] Connector ${device.connectorId} for device ${internalDeviceId} not found.`);
+            throw new Error(`Connector configuration not found for device.`);
+        }
+
+        console.log(`[DeviceActions] Found connector: ${connector.id}, Category: ${connector.category}`);
+
+        // 3. Check if rename is supported for this connector category
+        if (!isRenameSupported(connector.category)) {
+            console.warn(`[DeviceActions] Rename not supported for connector category '${connector.category}'.`);
+            throw new Error(`Device renaming is not supported for ${connector.category} devices.`);
+        }
+
+        // 4. Parse Config using the same pattern
+        let parsedConfig: any;
+        try {
+            parsedConfig = JSON.parse(connector.cfg_enc);
+        } catch (e) {
+            console.error(`[DeviceActions] Failed to parse configuration for connector ${connector.id}:`, e);
+            throw new Error(`Invalid connector configuration.`);
+        }
+
+        // 5. Call the appropriate driver function
+        if (connector.category === 'piko') {
+            console.log(`[DeviceActions] Calling renamePikoDevice for ${device.deviceId}`);
+            await renamePikoDevice(device.connectorId, device.deviceId, newName);
+        } else if (connector.category === 'genea') {
+            console.log(`[DeviceActions] Calling updateGeneaDoor for ${device.deviceId}`);
+            
+            // For Genea, we need to provide is_elevator_door from the current device data
+            // since the API requires it even for name-only updates
+            const payload: any = { name: newName };
+            
+            if (device.rawDeviceData && typeof device.rawDeviceData === 'object') {
+                const rawData = device.rawDeviceData as any;
+                if (typeof rawData.is_elevator_door === 'boolean') {
+                    payload.is_elevator_door = rawData.is_elevator_door;
+                }
+            }
+            
+            // Import and use updateGeneaDoor instead of renameGeneaDoor for more control
+            const { updateGeneaDoor } = await import('@/services/drivers/genea');
+            await updateGeneaDoor(parsedConfig, device.deviceId, payload);
+        }
+
+        console.log(`[DeviceActions] Successfully renamed device ${device.deviceId} to "${newName}"`);
+        return true;
+
+    } catch (error) {
+        console.error(`[DeviceActions] Error during requestDeviceRename for ${internalDeviceId}:`, error);
+        // Re-throw the error to be handled by the API endpoint
+        if (error instanceof Error) {
+            throw error; 
+        } else {
+            throw new Error('An unknown error occurred while renaming device.');
         }
     }
 } 

--- a/src/services/drivers/genea.ts
+++ b/src/services/drivers/genea.ts
@@ -550,3 +550,114 @@ export async function getGeneaDoors(config: GeneaConfig): Promise<GeneaDoor[]> {
     throw error instanceof Error ? error : new Error('Unknown error fetching Genea doors');
   }
 }
+
+// ###################################################################################
+// #                         DEVICE UPDATE FUNCTIONS                                #
+// ###################################################################################
+
+export type GeneaDoorUpdatePayload = {
+  name?: string;
+  description?: string;
+  is_elevator_door?: boolean;
+};
+
+/**
+ * Updates a Genea door with the specified payload.
+ * @param config - The Genea connector configuration containing the API key.
+ * @param doorUuid - The UUID of the door to update.
+ * @param payload - The update payload containing fields to modify.
+ * @returns A promise that resolves to the updated door data.
+ */
+export async function updateGeneaDoor(config: GeneaConfig, doorUuid: string, payload: GeneaDoorUpdatePayload): Promise<GeneaDoor> {
+  const validation = z.object({ 
+    apiKey: z.string().min(1) 
+  }).safeParse(config);
+
+  if (!validation.success) {
+    console.error("Invalid Genea config provided for updating door:", validation.error);
+    throw new Error('Invalid configuration: API Key is required.');
+  }
+
+  if (!doorUuid || typeof doorUuid !== 'string') {
+    console.error("Invalid door UUID provided for updating:", doorUuid);
+    throw new Error('Invalid door UUID provided.');
+  }
+
+  const { apiKey } = validation.data;
+
+  try {
+    console.log(`[Genea Driver] Updating door ${doorUuid} with payload:`, payload);
+    
+    const response = await fetch(`${GENEA_API_BASE_URL}/v2/door/${doorUuid}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Genea API returned status: ${response.status} when updating door ${doorUuid}`;
+      let detailedError = null;
+      
+      try {
+        const errorBody = await response.json();
+        detailedError = errorBody;
+        
+        if (response.status === 422) {
+          if (errorBody?.meta?.message) {
+            errorMessage = errorBody.meta.message;
+          } else if (errorBody?.error?.message) {
+            errorMessage = errorBody.error.message;
+          } else {
+            errorMessage = `Door update failed - request cannot be processed (invalid data or device restrictions)`;
+          }
+        } else {
+          errorMessage = errorBody?.meta?.message || errorBody?.error?.message || errorBody?.error || errorMessage;
+        }
+      } catch (e) {
+        console.warn("Could not parse error response body from Genea update API.");
+        if (response.status === 422) {
+          errorMessage = `Door update failed - request cannot be processed (invalid data or device restrictions)`;
+        }
+      }
+      
+      console.error(`[Genea Driver] Update error for ${doorUuid}:`, { status: response.status, errorMessage, detailedError });
+      throw new Error(errorMessage);
+    }
+
+    const responseBody = await response.json();
+    
+    // Validate the response structure
+    const parseResult = z.object({
+      data: GeneaDoorSchema,
+      meta: z.object({
+        message: z.string()
+      }).optional()
+    }).safeParse(responseBody);
+
+    if (!parseResult.success) {
+      console.error(`[Genea Driver] Invalid response structure when updating door ${doorUuid}:`, parseResult.error);
+      throw new Error('Invalid response format from Genea update API.');
+    }
+
+    console.log(`[Genea Driver] Successfully updated door ${doorUuid}. Response:`, parseResult.data.meta?.message || 'Success');
+    return parseResult.data.data;
+
+  } catch (error: unknown) {
+    console.error(`[Genea Driver] Error updating door ${doorUuid}:`, error);
+    throw error instanceof Error ? error : new Error(`Unknown error updating door ${doorUuid}`);
+  }
+}
+
+/**
+ * Renames a Genea door.
+ * @param config - The Genea connector configuration containing the API key.
+ * @param doorUuid - The UUID of the door to rename.
+ * @param newName - The new name for the door.
+ * @returns A promise that resolves to the updated door data.
+ */
+export async function renameGeneaDoor(config: GeneaConfig, doorUuid: string, newName: string): Promise<GeneaDoor> {
+  return updateGeneaDoor(config, doorUuid, { name: newName });
+}

--- a/src/services/drivers/genea.ts
+++ b/src/services/drivers/genea.ts
@@ -578,7 +578,7 @@ export async function updateGeneaDoor(config: GeneaConfig, doorUuid: string, pay
     throw new Error('Invalid configuration: API Key is required.');
   }
 
-  if (!doorUuid || typeof doorUuid !== 'string') {
+  if (!doorUuid || typeof doorUuid !== 'string' || !doorUuid.trim()) {
     console.error("Invalid door UUID provided for updating:", doorUuid);
     throw new Error('Invalid door UUID provided.');
   }
@@ -588,7 +588,8 @@ export async function updateGeneaDoor(config: GeneaConfig, doorUuid: string, pay
   try {
     console.log(`[Genea Driver] Updating door ${doorUuid} with payload:`, payload);
     
-    const response = await fetch(`${GENEA_API_BASE_URL}/v2/door/${doorUuid}`, {
+    const safeDoorUuid = doorUuid.trim();
+    const response = await fetch(`${GENEA_API_BASE_URL}/v2/door/${safeDoorUuid}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',

--- a/src/services/drivers/piko.ts
+++ b/src/services/drivers/piko.ts
@@ -1305,8 +1305,11 @@ export async function updatePikoDevice(
 ): Promise<PikoDeviceRaw> {
   const logPrefix = `[updatePikoDevice][${connectorId}][Device: ${deviceId.substring(0, 8)}...]`;
   console.log(`${logPrefix} Patching device with _strict=true`);
-  if (!deviceId) throw new PikoApiError('Device ID required.', { statusCode: 400, errorId: PikoErrorCode.MissingParameter });
-  const path = `/rest/v3/devices/${deviceId}`;
+  if (!deviceId || typeof deviceId !== 'string' || !deviceId.trim()) {
+    throw new PikoApiError('Device ID required and must be a non-empty string.', { statusCode: 400, errorId: PikoErrorCode.MissingParameter });
+  }
+  const safeDeviceId = deviceId.trim();
+  const path = `/rest/v3/devices/${safeDeviceId}`;
   const queryParams = { _strict: 'true' } as Record<string, string>;
   const data = await pikoApiClient.request({
     connectorId,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1767,7 +1767,11 @@ export const useFusionStore = create<FusionState>((set, get) => ({
         throw new Error(message);
       }
 
-      const newNameFromServer = parsed.data?.data?.name as string;
+      const nameParseResult = z.string().safeParse(parsed.data?.data?.name);
+      if (!nameParseResult.success) {
+        throw new Error('Invalid device name returned from server');
+      }
+      const newNameFromServer = nameParseResult.data;
 
       // Update allDevices list and deviceStates map via helper
       set((state) => updateDeviceNameInState(state, internalDeviceId, newNameFromServer));

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1659,9 +1659,8 @@ export const useFusionStore = create<FusionState>((set, get) => ({
     const loadingToastId = toast.loading(loadingMessage);
 
     try {
-      const baseUrl = process.env.APP_URL || '';
-      // 2. Make API Call
-      const response = await fetch(`${baseUrl}/api/devices/${internalDeviceId}/state`, {
+      // 2. Make API Call (relative URL; no base origin needed)
+      const response = await fetch(`/api/devices/${internalDeviceId}/state`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ state: newState }),
@@ -1733,11 +1732,10 @@ export const useFusionStore = create<FusionState>((set, get) => ({
       return { deviceRenameLoading: next };
     });
 
-    const baseUrl = process.env.APP_URL || '';
     const loadingToastId = toast.loading('Renaming device...');
 
     try {
-      const response = await fetch(`${baseUrl}/api/devices/${internalDeviceId}/name`, {
+      const response = await fetch(`/api/devices/${internalDeviceId}/name`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: newName.trim() }),
@@ -1753,7 +1751,7 @@ export const useFusionStore = create<FusionState>((set, get) => ({
       const parsed = RenameResponseSchema.safeParse(json);
 
       if (!parsed.success || !response.ok || !parsed.data.success || !parsed.data.data) {
-        const err = parsed.success ? parsed.data.error : (json as any)?.error;
+        const err = parsed.success ? parsed.data?.error : (json as any)?.error;
         const message =
           (typeof err === 'string' && err) ||
           ((err as any)?.message as string | undefined) ||
@@ -1761,7 +1759,7 @@ export const useFusionStore = create<FusionState>((set, get) => ({
         throw new Error(message);
       }
 
-      const newNameFromServer = parsed.data.data.name;
+      const newNameFromServer = parsed.data?.data?.name as string;
 
       // Update allDevices list and deviceStates map
       set((state) => {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1750,8 +1750,16 @@ export const useFusionStore = create<FusionState>((set, get) => ({
       const json = await response.json().catch(() => null);
       const parsed = RenameResponseSchema.safeParse(json);
 
+      // Helper to safely extract an error value from an unknown JSON
+      const extractError = (raw: unknown): unknown => {
+        if (raw && typeof raw === 'object' && 'error' in (raw as Record<string, unknown>)) {
+          return (raw as Record<string, unknown>).error;
+        }
+        return undefined;
+      };
+
       if (!parsed.success || !response.ok || !parsed.data.success || !parsed.data.data) {
-        const err = parsed.success ? parsed.data?.error : (json as any)?.error;
+        const err = parsed.success ? parsed.data?.error : extractError(json);
         const message =
           (typeof err === 'string' && err) ||
           ((err as any)?.message as string | undefined) ||

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1761,24 +1761,8 @@ export const useFusionStore = create<FusionState>((set, get) => ({
 
       const newNameFromServer = parsed.data?.data?.name as string;
 
-      // Update allDevices list and deviceStates map
-      set((state) => {
-        const updatedAll = state.allDevices.map((d) => (
-          d.id === internalDeviceId ? { ...d, name: newNameFromServer } : d
-        ));
-
-        const target = state.allDevices.find((d) => d.id === internalDeviceId);
-        const newMap = new Map(state.deviceStates);
-        if (target) {
-          const key = `${target.connectorId}:${target.deviceId}`;
-          const existing = newMap.get(key);
-          if (existing) {
-            newMap.set(key, { ...existing, name: newNameFromServer });
-          }
-        }
-
-        return { allDevices: updatedAll, deviceStates: newMap };
-      });
+      // Update allDevices list and deviceStates map via helper
+      set((state) => updateDeviceNameInState(state, internalDeviceId, newNameFromServer));
 
       toast.success('Device renamed successfully.', { id: loadingToastId });
       return true;
@@ -3311,6 +3295,29 @@ export const useFusionStore = create<FusionState>((set, get) => ({
   },
 
 })); 
+
+// --- Local helper to update device name in both lists and map ---
+function updateDeviceNameInState(
+  state: FusionState,
+  internalDeviceId: string,
+  newName: string
+): Pick<FusionState, 'allDevices' | 'deviceStates'> {
+  const updatedAll = state.allDevices.map((d) => (
+    d.id === internalDeviceId ? { ...d, name: newName } : d
+  ));
+
+  const target = state.allDevices.find((d) => d.id === internalDeviceId);
+  const newMap = new Map(state.deviceStates);
+  if (target) {
+    const key = `${target.connectorId}:${target.deviceId}`;
+    const existing = newMap.get(key);
+    if (existing) {
+      newMap.set(key, { ...existing, name: newName });
+    }
+  }
+
+  return { allDevices: updatedAll, deviceStates: newMap };
+}
 
 // --- Organization Types ---
 export interface Organization {


### PR DESCRIPTION
This pull request introduces device renaming functionality for supported connector types, with both backend and frontend changes to enable users to rename devices inline in the UI. The backend adds a new API endpoint and service logic for renaming devices, while the frontend updates the device detail dialog to support inline editing for eligible devices. Documentation is also updated to cover the new capability and extension patterns.

**Backend: Device Renaming Support**
- Added `PATCH /api/devices/[internalDeviceId]/name` API endpoint, which validates input and calls the new `requestDeviceRename` service to perform renaming, including local DB updates. ([src/app/api/devices/[internalDeviceId]/name/route.tsR1-R59](diffhunk://#diff-573d3797ba6ba3ebf74b7e3c25b949a01a680eea97787aa2d9a5b89047a398eeR1-R59))
- Implemented `requestDeviceRename` in `device-actions/index.ts`, supporting Piko and Genea connectors, with proper config lookup and handling of required fields for Genea.

**Frontend: Inline Device Name Editing**
- Updated `device-detail-dialog-content.tsx` to show an inline editable name field for devices where renaming is supported, using local state and calling `renameDevice` on submit or blur.
- Integrated `isRenameSupported` capability check and UI state management for rename operations, including loading indicators and error handling. [[1]](diffhunk://#diff-5479414c33ee4544839903a811199b34559879bd0ac362fb562e16c0c7543a75L11-R12) [[2]](diffhunk://#diff-5479414c33ee4544839903a811199b34559879bd0ac362fb562e16c0c7543a75R140-R141) [[3]](diffhunk://#diff-5479414c33ee4544839903a811199b34559879bd0ac362fb562e16c0c7543a75R243-R247)

**Capabilities & Extension**
- Added `RENAMEABLE_CONNECTOR_CATEGORIES` and related helpers (`isRenameSupported`, `isRenameableOption`) to `capabilities.ts` for centralized capability checks.

**Documentation**
- Updated `device-actions/README.md` to document the new renaming API, connector support, and extension instructions for adding renaming to new connectors. [[1]](diffhunk://#diff-aae1c61bc2881523082e1015f6e35b9a9b2a8f9876da86bf2b89078239c3adc2L40-R51) [[2]](diffhunk://#diff-aae1c61bc2881523082e1015f6e35b9a9b2a8f9876da86bf2b89078239c3adc2R67-R73) [[3]](diffhunk://#diff-aae1c61bc2881523082e1015f6e35b9a9b2a8f9876da86bf2b89078239c3adc2L80-R88) [[4]](diffhunk://#diff-aae1c61bc2881523082e1015f6e35b9a9b2a8f9876da86bf2b89078239c3adc2R100-R112) [[5]](diffhunk://#diff-aae1c61bc2881523082e1015f6e35b9a9b2a8f9876da86bf2b89078239c3adc2R144-R163)