### PR TITLE
Add fisheye dewarp feature to video player grid

### DIFF
--- a/src/app/(features)/play/page.tsx
+++ b/src/app/(features)/play/page.tsx
@@ -20,6 +20,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { EditCamerasDialog } from "@/components/features/play/EditCamerasDialog";
 import { toast } from "sonner";
 
+
 export default function PlayPage() {
   const allDevices = useFusionStore((state) => state.allDevices);
   const isLoadingAllDevices = useFusionStore(
@@ -58,6 +59,7 @@ export default function PlayPage() {
   const [prefs, setPrefs] = useState<{ defaultLayoutId: string | null }>({
     defaultLayoutId: null,
   });
+
 
   const [isPlayFullScreen, setIsPlayFullScreen] = useState(false);
   const playFullScreenContainerRef = useRef<HTMLDivElement>(null);
@@ -483,6 +485,7 @@ export default function PlayPage() {
               }}
             />
           </div>
+
         </DialogContent>
       </Dialog>
     </div>

--- a/src/components/features/piko/DewarpMenuSub.tsx
+++ b/src/components/features/piko/DewarpMenuSub.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import {
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { Aperture, SlidersHorizontal } from 'lucide-react';
+
+interface DewarpMenuSubProps {
+  enabled: boolean;
+  onToggleEnabled: () => void;
+  onOpenSettings: () => void;
+}
+
+export const DewarpMenuSub: React.FC<DewarpMenuSubProps> = ({
+  enabled,
+  onToggleEnabled,
+  onOpenSettings,
+}) => {
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <Aperture className="mr-2 h-4 w-4" />
+        Dewarp
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleEnabled();
+          }}
+        >
+          <Aperture className="mr-2 h-4 w-4" />
+          {enabled ? 'Disable dewarp' : 'Enable dewarp'}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() => onOpenSettings()}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOpenSettings();
+          }}
+        >
+          <SlidersHorizontal className="mr-2 h-4 w-4" />
+          Advanced
+        </DropdownMenuItem>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+};

--- a/src/components/features/piko/DewarpSettings.tsx
+++ b/src/components/features/piko/DewarpSettings.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { SlidersHorizontal } from 'lucide-react';
+import type { DewarpSettings, LensModel } from '@/types/video-dewarp';
+
+export interface DewarpSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings: DewarpSettings;
+  onChange: (s: DewarpSettings) => void;
+}
+
+export const DewarpSettingsDialog: React.FC<DewarpSettingsDialogProps> = ({ 
+  open, 
+  onOpenChange, 
+  settings, 
+  onChange 
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+            Advanced Dewarp Settings
+          </DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-6">
+          {/* Primary View Controls */}
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Field of View</Label>
+              <p className="text-xs text-muted-foreground">How wide the output view should be</p>
+              <div className="flex items-center gap-3">
+                <Slider 
+                  className="flex-1" 
+                  min={30} max={150} step={1} 
+                  value={[settings.fovDeg]} 
+                  onValueChange={(v)=>onChange({ ...settings, fovDeg: v[0] ?? settings.fovDeg })} 
+                />
+                <Input 
+                  className="h-8 w-16 text-right" 
+                  value={Math.round(settings.fovDeg)} 
+                  onChange={(e)=>{
+                    const n = Number(e.currentTarget.value); 
+                    if(!Number.isNaN(n)) onChange({ ...settings, fovDeg: Math.max(1, Math.min(170, n)) });
+                  }} 
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Yaw</Label>
+                <p className="text-xs text-muted-foreground">Pan left/right</p>
+                <Slider min={-180} max={180} step={1} value={[settings.yawDeg]} onValueChange={(v)=>onChange({ ...settings, yawDeg: v[0] ?? settings.yawDeg })} />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Pitch</Label>
+                <p className="text-xs text-muted-foreground">Tilt up/down</p>
+                <Slider min={-89} max={89} step={1} value={[settings.pitchDeg]} onValueChange={(v)=>onChange({ ...settings, pitchDeg: v[0] ?? settings.pitchDeg })} />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Roll</Label>
+                <p className="text-xs text-muted-foreground">Rotate image</p>
+                <Slider min={-180} max={180} step={1} value={[settings.rollDeg]} onValueChange={(v)=>onChange({ ...settings, rollDeg: v[0] ?? settings.rollDeg })} />
+              </div>
+            </div>
+          </div>
+
+          {/* Lens Calibration */}
+          <div className="space-y-4 border-t pt-4">
+            <div>
+              <Label className="text-sm font-medium">Lens Calibration</Label>
+              <p className="text-xs text-muted-foreground">Advanced settings for specific fisheye lenses</p>
+            </div>
+            
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Lens Model</Label>
+                <p className="text-xs text-muted-foreground">Mathematical model for lens distortion</p>
+                <Select value={settings.lensModel} onValueChange={(v)=> onChange({ ...settings, lensModel: v as LensModel })}>
+                  <SelectTrigger className="w-full text-left">
+                    <SelectValue placeholder="Lens model">
+                      {settings.lensModel === 'equidistant' && 'Equidistant'}
+                      {settings.lensModel === 'equisolid' && 'Equisolid'}
+                      {settings.lensModel === 'orthographic' && 'Orthographic'}
+                      {settings.lensModel === 'stereographic' && 'Stereographic'}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="equidistant">
+                      <div>
+                        <div>Equidistant</div>
+                        <div className="text-xs text-muted-foreground">Standard fisheye - distance from center proportional to angle</div>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="equisolid">
+                      <div>
+                        <div>Equisolid</div>
+                        <div className="text-xs text-muted-foreground">Equal area projection - preserves relative sizes</div>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="orthographic">
+                      <div>
+                        <div>Orthographic</div>
+                        <div className="text-xs text-muted-foreground">Wide angle lenses - sine projection</div>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="stereographic">
+                      <div>
+                        <div>Stereographic</div>
+                        <div className="text-xs text-muted-foreground">Perspective projection - preserves angles</div>
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Optical Center & Focal Length</Label>
+                <p className="text-xs text-muted-foreground">Fine-tune lens center position and distortion strength</p>
+                <div className="grid grid-cols-3 gap-3">
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Center X</Label>
+                    <Input 
+                      placeholder="auto" 
+                      className="h-8" 
+                      value={settings.cx ?? ''} 
+                      onChange={(e)=>{
+                        const n = Number(e.currentTarget.value); 
+                        onChange({ ...settings, cx: Number.isNaN(n) ? undefined : n });
+                      }} 
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Center Y</Label>
+                    <Input 
+                      placeholder="auto" 
+                      className="h-8" 
+                      value={settings.cy ?? ''} 
+                      onChange={(e)=>{
+                        const n = Number(e.currentTarget.value); 
+                        onChange({ ...settings, cy: Number.isNaN(n) ? undefined : n });
+                      }} 
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1 block">Focal (px)</Label>
+                    <Input 
+                      placeholder="auto" 
+                      className="h-8" 
+                      value={settings.focalPx ?? ''} 
+                      onChange={(e)=>{
+                        const n = Number(e.currentTarget.value); 
+                        onChange({ ...settings, focalPx: Number.isNaN(n) ? undefined : n });
+                      }} 
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/features/piko/DewarpViewControls.tsx
+++ b/src/components/features/piko/DewarpViewControls.tsx
@@ -15,11 +15,13 @@ interface DewarpViewControlsProps {
 
 /**
  * Computes the safe pitch limit in degrees so the output FOV edge remains within the fisheye circle.
- * Formula: max(0, π/2 − FOV/2) in radians, then converted to degrees.
- * Assumes ~180° fisheye coverage (θ_max ≈ π/2 from center).
+ * Formula: max(0, θ_max − FOV/2) in radians, then converted to degrees.
+ * @param outputFovDeg - Output field of view in degrees.
+ * @param fisheyeCoverageDeg - Total fisheye coverage in degrees (defaults to 180°, set 200–220° for some 360 lenses).
+ * Note: If fisheyeCoverageDeg is not set correctly for the camera, pitch limits may be inaccurate.
  */
-function calculateSafePitchLimitDegrees(outputFovDeg: number): number {
-  const maxFisheyeTheta = Math.PI / 2;
+function calculateSafePitchLimitDegrees(outputFovDeg: number, fisheyeCoverageDeg: number = 180): number {
+  const maxFisheyeTheta = (fisheyeCoverageDeg * Math.PI) / 360; // half-angle in radians
   const outFovRad = (outputFovDeg * Math.PI) / 180;
   return Math.max(0, maxFisheyeTheta - outFovRad / 2) * (180 / Math.PI);
 }

--- a/src/components/features/piko/DewarpViewControls.tsx
+++ b/src/components/features/piko/DewarpViewControls.tsx
@@ -60,9 +60,7 @@ export const DewarpViewControls: React.FC<DewarpViewControlsProps> = ({
           const outFovRad = (settings.fovDeg * Math.PI) / 180;
           const maxRayAngle = Math.atan(Math.tan(outFovRad / 2));
           
-          // Limit pitch to prevent rays from going beyond fisheye coverage
-          // When looking straight ahead (pitch=0), corner rays have angle = outFovRad/2
-          // When looking up/down, we need to ensure corner rays don't exceed maxFisheyeTheta
+          // Limit pitch so the edge of the output FOV stays within the fisheye circle: safePitchLimit = max(0, pi/2 - outFovRad/2) in degrees
           const safePitchLimit = Math.max(0, maxFisheyeTheta - (outFovRad / 2)) * (180 / Math.PI);
           
           onChange({

--- a/src/components/features/piko/DewarpViewControls.tsx
+++ b/src/components/features/piko/DewarpViewControls.tsx
@@ -13,6 +13,17 @@ interface DewarpViewControlsProps {
   topOffsetPx?: number; // reserve a safe area at the top (e.g. overlay header region)
 }
 
+/**
+ * Computes the safe pitch limit in degrees so the output FOV edge remains within the fisheye circle.
+ * Formula: max(0, π/2 − FOV/2) in radians, then converted to degrees.
+ * Assumes ~180° fisheye coverage (θ_max ≈ π/2 from center).
+ */
+function calculateSafePitchLimitDegrees(outputFovDeg: number): number {
+  const maxFisheyeTheta = Math.PI / 2;
+  const outFovRad = (outputFovDeg * Math.PI) / 180;
+  return Math.max(0, maxFisheyeTheta - outFovRad / 2) * (180 / Math.PI);
+}
+
 export const DewarpViewControls: React.FC<DewarpViewControlsProps> = ({
   settings,
   onChange,
@@ -51,17 +62,8 @@ export const DewarpViewControls: React.FC<DewarpViewControlsProps> = ({
           const yawDelta = deltaX * 0.5;
           const pitchDelta = -deltaY * 0.5; // Invert Y for natural feel
           
-          // Calculate maximum allowed theta for fisheye circle
-          // For a typical fisheye, the circle covers about 180° field of view
-          // The maximum theta we can sample is around π/2 (90°) from center
-          const maxFisheyeTheta = Math.PI / 2; // 90 degrees in radians
-          
-          // For our output FOV, calculate the maximum ray angle from center
-          const outFovRad = (settings.fovDeg * Math.PI) / 180;
-          const maxRayAngle = Math.atan(Math.tan(outFovRad / 2));
-          
-          // Limit pitch so the edge of the output FOV stays within the fisheye circle: safePitchLimit = max(0, pi/2 - outFovRad/2) in degrees
-          const safePitchLimit = Math.max(0, maxFisheyeTheta - (outFovRad / 2)) * (180 / Math.PI);
+          // Limit pitch so the edge of the output FOV stays within the fisheye circle
+          const safePitchLimit = calculateSafePitchLimitDegrees(settings.fovDeg);
           
           onChange({
             ...settings,

--- a/src/components/features/piko/DewarpViewControls.tsx
+++ b/src/components/features/piko/DewarpViewControls.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { Plus, Minus, Aperture } from 'lucide-react';
+import type { DewarpSettings } from '@/types/video-dewarp';
+
+interface DewarpViewControlsProps {
+  settings: DewarpSettings;
+  onChange: (settings: DewarpSettings) => void;
+  className?: string;
+  topOffsetPx?: number; // reserve a safe area at the top (e.g. overlay header region)
+}
+
+export const DewarpViewControls: React.FC<DewarpViewControlsProps> = ({
+  settings,
+  onChange,
+  className = '',
+  topOffsetPx = 0,
+}) => {
+  return (
+    <div 
+      className={`absolute right-0 bottom-0 left-0 z-30 cursor-move no-drag ${className}`}
+      style={{ top: topOffsetPx }}
+      onWheel={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        // Scroll up = zoom in (decrease FOV), scroll down = zoom out (increase FOV)
+        const delta = e.deltaY > 0 ? 5 : -5; // 5 degree increments
+        const newFov = Math.max(30, Math.min(150, settings.fovDeg + delta));
+        
+        if (newFov !== settings.fovDeg) {
+          onChange({ ...settings, fovDeg: newFov });
+        }
+      }}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const startYaw = settings.yawDeg;
+        const startPitch = settings.pitchDeg;
+        
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+          moveEvent.stopPropagation();
+          const deltaX = moveEvent.clientX - startX;
+          const deltaY = moveEvent.clientY - startY;
+          // Sensitivity: 1 pixel = 0.5 degrees
+          const yawDelta = deltaX * 0.5;
+          const pitchDelta = -deltaY * 0.5; // Invert Y for natural feel
+          
+          // Calculate maximum allowed theta for fisheye circle
+          // For a typical fisheye, the circle covers about 180° field of view
+          // The maximum theta we can sample is around π/2 (90°) from center
+          const maxFisheyeTheta = Math.PI / 2; // 90 degrees in radians
+          
+          // For our output FOV, calculate the maximum ray angle from center
+          const outFovRad = (settings.fovDeg * Math.PI) / 180;
+          const maxRayAngle = Math.atan(Math.tan(outFovRad / 2));
+          
+          // Limit pitch to prevent rays from going beyond fisheye coverage
+          // When looking straight ahead (pitch=0), corner rays have angle = outFovRad/2
+          // When looking up/down, we need to ensure corner rays don't exceed maxFisheyeTheta
+          const safePitchLimit = Math.max(0, maxFisheyeTheta - (outFovRad / 2)) * (180 / Math.PI);
+          
+          onChange({
+            ...settings,
+            yawDeg: startYaw + yawDelta, // Allow infinite rotation (no bounds)
+            pitchDeg: Math.max(-safePitchLimit, Math.min(safePitchLimit, startPitch + pitchDelta)),
+          });
+        };
+        
+        const handleMouseUp = (upEvent: MouseEvent) => {
+          upEvent.stopPropagation();
+          document.removeEventListener('mousemove', handleMouseMove);
+          document.removeEventListener('mouseup', handleMouseUp);
+        };
+        
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+      }}
+    >
+      {/* Top-left stack: icon indicator then controls */}
+      <div className="absolute top-4 left-4 flex flex-col gap-3 pointer-events-none">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div 
+                className="w-9 h-9 rounded-full bg-blue-500/80 text-white pointer-events-auto flex items-center justify-center"
+              >
+                <Aperture className="h-5 w-5" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Dewarp mode - drag to pan, use +/- to zoom</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <div className="flex flex-col gap-2 pointer-events-auto">
+          <Button
+            size="icon"
+            variant="secondary"
+            className="h-10 w-10 rounded-full bg-black/60 hover:bg-black/80 text-white border-white/20"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              const newFov = Math.max(30, settings.fovDeg - 10);
+              onChange({ ...settings, fovDeg: newFov });
+            }}
+          >
+            <Plus className="h-5 w-5" />
+          </Button>
+          <Button
+            size="icon"
+            variant="secondary"
+            className="h-10 w-10 rounded-full bg-black/60 hover:bg-black/80 text-white border-white/20"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              const newFov = Math.min(150, settings.fovDeg + 10);
+              onChange({ ...settings, fovDeg: newFov });
+            }}
+          >
+            <Minus className="h-5 w-5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+

--- a/src/components/features/piko/DewarpablePikoPlayer.tsx
+++ b/src/components/features/piko/DewarpablePikoPlayer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { PikoVideoPlayer } from '@/components/features/piko/piko-video-player';
+import { VideoDewarpCanvas } from '@/components/features/piko/VideoDewarpCanvas';
+import { DewarpViewControls } from '@/components/features/piko/DewarpViewControls';
+import type { DewarpSettings } from '@/types/video-dewarp';
+import Image from 'next/image';
+import { Loader2 } from 'lucide-react';
+
+export interface DewarpablePikoPlayerProps {
+  connectorId: string;
+  cameraId: string;
+  pikoSystemId?: string;
+  positionMs?: number;
+  className?: string;
+  dewarpEnabled?: boolean;
+  settings?: DewarpSettings;
+  onDewarpSettingsChange?: (settings: DewarpSettings) => void;
+  editOverlayTopOffsetPx?: number;
+  thumbnailSize?: string; // defaults to 320x0
+  enableStats?: boolean;
+  onStats?: (stats: { fps: number; width?: number; height?: number }) => void;
+}
+
+export const DewarpablePikoPlayer: React.FC<DewarpablePikoPlayerProps> = ({
+  connectorId,
+  cameraId,
+  pikoSystemId,
+  positionMs,
+  className,
+  dewarpEnabled = false,
+  settings,
+  onDewarpSettingsChange,
+  editOverlayTopOffsetPx = 0,
+  thumbnailSize = '320x0',
+  enableStats,
+  onStats,
+}) => {
+  const [isReady, setIsReady] = useState(false);
+  const [videoEl, setVideoEl] = useState<HTMLVideoElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [canvasSize, setCanvasSize] = useState<{ w: number; h: number }>({ w: 1280, h: 720 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      const rect = el.getBoundingClientRect();
+      setCanvasSize({ w: Math.max(1, Math.floor(rect.width)), h: Math.max(1, Math.floor(rect.height)) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const thumbnailSrc = useMemo(() => {
+    const url = new URL('/api/piko/device-thumbnail', window.location.origin);
+    url.searchParams.append('connectorId', connectorId);
+    url.searchParams.append('cameraId', cameraId);
+    url.searchParams.append('size', thumbnailSize);
+    return url.toString();
+  }, [connectorId, cameraId, thumbnailSize]);
+
+  return (
+    <div ref={containerRef} className={`relative w-full h-full ${className || ''}`}>
+      <PikoVideoPlayer
+        connectorId={connectorId}
+        pikoSystemId={pikoSystemId}
+        cameraId={cameraId}
+        positionMs={positionMs}
+        className="w-full h-full"
+        disableFullscreen
+        onReady={() => setIsReady(true)}
+        exposeVideoRef={setVideoEl}
+        showBuiltInSpinner={false}
+        enableStats={enableStats}
+        onStats={onStats}
+      />
+      {!isReady && (
+        <div className="absolute inset-0 z-[5] pointer-events-none transition-opacity duration-200 opacity-100">
+          <Image src={thumbnailSrc} alt="" fill unoptimized priority={false} className="object-contain bg-black" />
+        </div>
+      )}
+      {!isReady && (
+        <div className="absolute inset-0 flex items-center justify-center z-30 pointer-events-none">
+          <div className="rounded-md bg-black/10 p-2">
+            <Loader2 className="h-5 w-5 animate-spin text-white/90" />
+          </div>
+        </div>
+      )}
+      {dewarpEnabled && isReady && videoEl && settings && (
+        <VideoDewarpCanvas
+          video={videoEl}
+          width={canvasSize.w}
+          height={canvasSize.h}
+          settings={settings}
+          className="absolute inset-0 z-10"
+        />
+      )}
+      {dewarpEnabled && settings && onDewarpSettingsChange && (
+        <DewarpViewControls
+          settings={settings}
+          onChange={onDewarpSettingsChange}
+          topOffsetPx={editOverlayTopOffsetPx}
+        />
+      )}
+    </div>
+  );
+};
+
+

--- a/src/components/features/piko/VideoDewarpCanvas.tsx
+++ b/src/components/features/piko/VideoDewarpCanvas.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import type { DewarpSettings, LensModel } from '@/types/video-dewarp';
+
+export interface VideoDewarpCanvasProps {
+  video: HTMLVideoElement | null;
+  width: number;
+  height: number;
+  settings: DewarpSettings;
+  className?: string;
+}
+
+// Minimal WebGL-based dewarp using a full-screen quad
+export const VideoDewarpCanvas: React.FC<VideoDewarpCanvasProps> = ({
+  video,
+  width,
+  height,
+  settings,
+  className,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const glRef = useRef<WebGL2RenderingContext | WebGLRenderingContext | null>(null);
+  const programRef = useRef<WebGLProgram | null>(null);
+  const texRef = useRef<WebGLTexture | null>(null);
+  const vaoRef = useRef<WebGLVertexArrayObject | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const vertexSrc = useMemo(
+    () => `#version 300 es
+in vec2 aPos;
+out vec2 vUv;
+void main(){
+  vUv = (aPos + 1.0) * 0.5;
+  gl_Position = vec4(aPos, 0.0, 1.0);
+}
+`,
+    []
+  );
+
+  const fragmentSrc = useMemo(
+    () => `#version 300 es
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uTex;
+uniform vec2 uTexSize;
+uniform vec2 uCenter;
+uniform float uFocal;
+uniform float uOutFov; // radians
+uniform mat3 uR;
+uniform int uLensModel; // 0=equidistant,1=equisolid,2=orthographic,3=stereographic
+
+vec3 rayFromUV(vec2 uv){
+  float f = tan(uOutFov * 0.5);
+  float x = (uv.x * 2.0 - 1.0) * f;
+  float y = (1.0 - uv.y * 2.0) * f;
+  return normalize(vec3(x, y, -1.0));
+}
+
+float rFromTheta(float theta){
+  if(uLensModel==0){
+    return uFocal * theta; // equidistant
+  } else if(uLensModel==1){
+    return 2.0 * uFocal * sin(theta*0.5); // equisolid
+  } else if(uLensModel==2){
+    return uFocal * sin(theta); // orthographic
+  } else {
+    return 2.0 * uFocal * tan(theta*0.5); // stereographic
+  }
+}
+
+void main(){
+  vec3 d = rayFromUV(vUv);
+  d = uR * d;
+  float theta = acos(clamp(-d.z, -1.0, 1.0));
+  float r = rFromTheta(theta);
+  float phi = atan(d.y, d.x);
+  vec2 p = uCenter + r * vec2(cos(phi), sin(phi));
+  vec2 uv = p / uTexSize;
+  if(any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0)))){
+    fragColor = vec4(0.0,0.0,0.0,1.0);
+    return;
+  }
+  vec3 c = texture(uTex, uv).rgb;
+  fragColor = vec4(c,1.0);
+}
+`,
+    []
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = (canvas.getContext('webgl2') || canvas.getContext('webgl')) as
+      | WebGL2RenderingContext
+      | WebGLRenderingContext
+      | null;
+    if (!gl) return;
+    glRef.current = gl;
+
+    function createShader(type: number, src: string) {
+      if (!gl) return null;
+      const s = gl.createShader(type);
+      if (!s) return null;
+      gl.shaderSource(s, src);
+      gl.compileShader(s);
+      if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+        console.error(gl.getShaderInfoLog(s));
+        gl.deleteShader(s);
+        return null;
+      }
+      return s;
+    }
+    const isWebGL2 = (gl as WebGL2RenderingContext).TEXTURE_BINDING_2D !== undefined;
+    const vs = createShader(gl.VERTEX_SHADER, vertexSrc.replace('#version 300 es', isWebGL2 ? '#version 300 es' : ''));
+    const fs = createShader(gl.FRAGMENT_SHADER, fragmentSrc.replace('#version 300 es', isWebGL2 ? '#version 300 es' : ''));
+    if (!vs || !fs) return;
+    const prog = gl.createProgram();
+    if (!prog) return;
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.bindAttribLocation(prog, 0, 'aPos');
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+      console.error(gl.getProgramInfoLog(prog));
+      return;
+    }
+    programRef.current = prog;
+
+    // Quad
+    const positions = new Float32Array([
+      -1, -1,
+      1, -1,
+      -1, 1,
+      -1, 1,
+      1, -1,
+      1, 1,
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    // VAO (webgl2) optional
+    if ('createVertexArray' in gl) {
+      const vao = (gl as WebGL2RenderingContext).createVertexArray();
+      vaoRef.current = vao as any;
+      (gl as WebGL2RenderingContext).bindVertexArray(vao);
+    }
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+    // Texture
+    const tex = gl.createTexture();
+    texRef.current = tex;
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    const render = () => {
+      if (!video || !video.videoWidth || !video.videoHeight) {
+        rafRef.current = requestAnimationFrame(render);
+        return;
+      }
+      const vw = video.videoWidth;
+      const vh = video.videoHeight;
+
+      // Resize canvas
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+
+      // Calculate aspect ratio preservation (letterbox/pillarbox)
+      const videoAspect = vw / vh;
+      const containerAspect = width / height;
+      
+      let viewportWidth, viewportHeight, viewportX, viewportY;
+      
+      if (videoAspect > containerAspect) {
+        // Video is wider - letterbox (black bars top/bottom)
+        viewportWidth = width;
+        viewportHeight = width / videoAspect;
+        viewportX = 0;
+        viewportY = (height - viewportHeight) / 2;
+      } else {
+        // Video is taller - pillarbox (black bars left/right)
+        viewportWidth = height * videoAspect;
+        viewportHeight = height;
+        viewportX = (width - viewportWidth) / 2;
+        viewportY = 0;
+      }
+
+      // Clear entire canvas to black
+      gl.clearColor(0, 0, 0, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      
+      // Set viewport to correctly sized region
+      gl.viewport(viewportX, viewportY, viewportWidth, viewportHeight);
+
+      // Upload current frame
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      try {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
+      } catch {}
+
+      gl.useProgram(prog);
+      const getLoc = (name: string) => gl.getUniformLocation(prog, name);
+
+      const lensModelIndex = lensModelToIndex(settings.lensModel);
+      const cx = settings.cx ?? vw * 0.5;
+      const cy = settings.cy ?? vh * 0.5;
+      const Rguess = Math.min(cx, cy);
+      const f = settings.focalPx ?? Rguess / (Math.PI * 0.5);
+
+      // Build rotation matrix from yaw(Z), pitch(X), roll(Y)
+      const yaw = deg2rad(settings.yawDeg);
+      const pitch = deg2rad(settings.pitchDeg);
+      const roll = deg2rad(settings.rollDeg);
+      const Ryaw = zRot(yaw);
+      const Rpitch = xRot(pitch);
+      const Rroll = yRot(roll);
+      const R = mulMat3(mulMat3(Ryaw, Rpitch), Rroll);
+
+      gl.uniform1i(getLoc('uLensModel'), lensModelIndex);
+      gl.uniform2f(getLoc('uTexSize'), vw, vh);
+      gl.uniform2f(getLoc('uCenter'), cx, cy);
+      gl.uniform1f(getLoc('uFocal'), f);
+      gl.uniform1f(getLoc('uOutFov'), deg2rad(settings.fovDeg));
+      gl.uniformMatrix3fv(getLoc('uR'), false, R);
+
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      rafRef.current = requestAnimationFrame(render);
+    };
+    rafRef.current = requestAnimationFrame(render);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (vaoRef.current && 'deleteVertexArray' in gl) {
+        (gl as WebGL2RenderingContext).deleteVertexArray(vaoRef.current);
+        vaoRef.current = null;
+      }
+      if (programRef.current) gl.deleteProgram(programRef.current);
+      if (texRef.current) gl.deleteTexture(texRef.current);
+      glRef.current = null;
+      programRef.current = null;
+      texRef.current = null;
+    };
+  }, [video, width, height, vertexSrc, fragmentSrc, settings]);
+
+  return <canvas ref={canvasRef} className={className} />;
+};
+
+function deg2rad(d: number): number { return (d * Math.PI) / 180; }
+function lensModelToIndex(m: LensModel): number {
+  switch (m) {
+    case 'equidistant': return 0;
+    case 'equisolid': return 1;
+    case 'orthographic': return 2;
+    case 'stereographic': return 3;
+  }
+}
+
+// Column-major mat3 as Float32Array[9]
+function mulMat3(A: Float32Array, B: Float32Array): Float32Array {
+  const a = A, b = B;
+  return new Float32Array([
+    a[0]*b[0] + a[3]*b[1] + a[6]*b[2],
+    a[1]*b[0] + a[4]*b[1] + a[7]*b[2],
+    a[2]*b[0] + a[5]*b[1] + a[8]*b[2],
+    a[0]*b[3] + a[3]*b[4] + a[6]*b[5],
+    a[1]*b[3] + a[4]*b[4] + a[7]*b[5],
+    a[2]*b[3] + a[5]*b[4] + a[8]*b[5],
+    a[0]*b[6] + a[3]*b[7] + a[6]*b[8],
+    a[1]*b[6] + a[4]*b[7] + a[7]*b[8],
+    a[2]*b[6] + a[5]*b[7] + a[8]*b[8],
+  ]);
+}
+function xRot(a: number): Float32Array {
+  const c = Math.cos(a), s = Math.sin(a);
+  return new Float32Array([
+    1, 0, 0,
+    0, c, s,
+    0, -s, c,
+  ]);
+}
+function yRot(a: number): Float32Array {
+  const c = Math.cos(a), s = Math.sin(a);
+  return new Float32Array([
+    c, 0, -s,
+    0, 1, 0,
+    s, 0, c,
+  ]);
+}
+function zRot(a: number): Float32Array {
+  const c = Math.cos(a), s = Math.sin(a);
+  return new Float32Array([
+    c, s, 0,
+    -s, c, 0,
+    0, 0, 1,
+  ]);
+}
+
+
+
+
+

--- a/src/components/features/piko/VideoDewarpCanvas.tsx
+++ b/src/components/features/piko/VideoDewarpCanvas.tsx
@@ -210,7 +210,12 @@ void main(){
           const vwInfo = video?.videoWidth ?? 0;
           const vhInfo = video?.videoHeight ?? 0;
           const srcInfo = video?.src ?? 'N/A';
-          console.error(`WebGL texture upload failed (videoWidth=${vwInfo}, videoHeight=${vhInfo}, src=${srcInfo})`, err);
+          const readyStateInfo = video?.readyState ?? -1;
+          const currentTimeInfo = video?.currentTime ?? -1;
+          console.error(
+            `WebGL texture upload failed (videoWidth=${vwInfo}, videoHeight=${vhInfo}, src=${srcInfo}, readyState=${readyStateInfo}, currentTime=${currentTimeInfo})`,
+            err
+          );
           uploadErrorLoggedRef.current = true;
         }
       }
@@ -224,6 +229,7 @@ void main(){
       const Rguess = Math.min(cx, cy);
       // Equidistant fisheye fallback: approximate focal length as f ≈ R / (π/2),
       // where R is the estimated fisheye radius to 90° from center. Used when focalPx is not provided.
+      // Note: This is an approximation and may be inaccurate for some fisheye lenses; dewarp quality can vary.
       const f = settings.focalPx ?? Rguess / (Math.PI * 0.5);
 
       // Build rotation matrix from yaw(Z), pitch(X), roll(Y)

--- a/src/components/features/piko/VideoDewarpCanvas.tsx
+++ b/src/components/features/piko/VideoDewarpCanvas.tsx
@@ -96,7 +96,10 @@ void main(){
 
     const gl = canvas.getContext('webgl2') as WebGL2RenderingContext | null;
     if (!gl) {
-      console.warn('WebGL2 not available; dewarping disabled');
+      console.warn(
+        'WebGL2 not available. Dewarping requires a modern browser with WebGL2 and hardware acceleration enabled. ' +
+        'Try updating your browser, switching to Chrome/Edge/Firefox/Safari 15+, or enabling hardware acceleration in settings.'
+      );
       return;
     }
     glRef.current = gl;
@@ -204,7 +207,10 @@ void main(){
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
       } catch (err) {
         if (!uploadErrorLoggedRef.current) {
-          console.error('WebGL texture upload failed:', err);
+          const vwInfo = video?.videoWidth ?? 0;
+          const vhInfo = video?.videoHeight ?? 0;
+          const srcInfo = video?.src ?? 'N/A';
+          console.error(`WebGL texture upload failed (videoWidth=${vwInfo}, videoHeight=${vhInfo}, src=${srcInfo})`, err);
           uploadErrorLoggedRef.current = true;
         }
       }
@@ -216,6 +222,8 @@ void main(){
       const cx = settings.cx ?? vw * 0.5;
       const cy = settings.cy ?? vh * 0.5;
       const Rguess = Math.min(cx, cy);
+      // Equidistant fisheye fallback: approximate focal length as f ≈ R / (π/2),
+      // where R is the estimated fisheye radius to 90° from center. Used when focalPx is not provided.
       const f = settings.focalPx ?? Rguess / (Math.PI * 0.5);
 
       // Build rotation matrix from yaw(Z), pitch(X), roll(Y)

--- a/src/components/features/piko/piko-video-player.tsx
+++ b/src/components/features/piko/piko-video-player.tsx
@@ -43,6 +43,8 @@ interface PikoVideoPlayerProps {
   onReady?: () => void;
   onError?: (message: string) => void;
   showBuiltInSpinner?: boolean; // default true; allows wrappers to hide built-in spinner
+  // Optional: expose the internal HTMLVideoElement for overlays (e.g., dewarping canvas)
+  exposeVideoRef?: (el: HTMLVideoElement | null) => void;
 }
 
 export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
@@ -57,6 +59,7 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
   onReady,
   onError,
   showBuiltInSpinner = true,
+  exposeVideoRef,
 }) => {
   const [isLoadingMediaInfo, setIsLoadingMediaInfo] = useState(true);
   const [mediaInfoError, setMediaInfoError] = useState<string | null>(null);
@@ -96,6 +99,13 @@ export const PikoVideoPlayer: React.FC<PikoVideoPlayerProps> = ({
   useEffect(() => {
     onErrorRef.current = onError;
   }, [onError]);
+  // Expose the underlying video element when available
+  useEffect(() => {
+    if (exposeVideoRef) exposeVideoRef(videoRef.current);
+    return () => {
+      if (exposeVideoRef) exposeVideoRef(null);
+    };
+  }, [exposeVideoRef]);
 
   // Dynamic import of the WebRTC library on the client side only
   useEffect(() => {

--- a/src/hooks/use-dewarp-controls.ts
+++ b/src/hooks/use-dewarp-controls.ts
@@ -1,0 +1,91 @@
+import { useState, useCallback } from 'react';
+import type { DewarpSettings } from '@/types/video-dewarp';
+
+const DEFAULT_DEWARP_SETTINGS: DewarpSettings = {
+  lensModel: 'equidistant',
+  fovDeg: 90,
+  yawDeg: 0,
+  pitchDeg: 0,
+  rollDeg: 0,
+};
+
+export interface DewarpDeviceState {
+  enabled: boolean;
+  settings: DewarpSettings;
+}
+
+export interface UseDewarpControlsReturn {
+  dewarpById: Record<string, DewarpDeviceState>;
+  enableDewarp: (deviceId: string, settings?: DewarpSettings) => void;
+  disableDewarp: (deviceId: string) => void;
+  toggleDewarp: (deviceId: string) => void;
+  updateSettings: (deviceId: string, settings: DewarpSettings) => void;
+  getSettings: (deviceId: string) => DewarpSettings;
+  isEnabled: (deviceId: string) => boolean;
+}
+
+export function useDewarpControls(): UseDewarpControlsReturn {
+  const [dewarpById, setDewarpById] = useState<Record<string, DewarpDeviceState>>({});
+
+  const enableDewarp = useCallback((deviceId: string, settings = DEFAULT_DEWARP_SETTINGS) => {
+    setDewarpById((prev) => ({
+      ...prev,
+      [deviceId]: { enabled: true, settings }
+    }));
+  }, []);
+
+  const disableDewarp = useCallback((deviceId: string) => {
+    setDewarpById((prev) => {
+      const current = prev[deviceId];
+      if (!current) return prev;
+      return {
+        ...prev,
+        [deviceId]: { ...current, enabled: false }
+      };
+    });
+  }, []);
+
+  const toggleDewarp = useCallback((deviceId: string) => {
+    setDewarpById((prev) => {
+      const current = prev[deviceId];
+      if (current?.enabled) {
+        return { ...prev, [deviceId]: { ...current, enabled: false } };
+      }
+      return { 
+        ...prev, 
+        [deviceId]: { 
+          enabled: true, 
+          settings: current?.settings || DEFAULT_DEWARP_SETTINGS 
+        } 
+      };
+    });
+  }, []);
+
+  const updateSettings = useCallback((deviceId: string, settings: DewarpSettings) => {
+    setDewarpById((prev) => ({
+      ...prev,
+      [deviceId]: {
+        enabled: true, // Auto-enable when updating settings
+        settings
+      }
+    }));
+  }, []);
+
+  const getSettings = useCallback((deviceId: string): DewarpSettings => {
+    return dewarpById[deviceId]?.settings || DEFAULT_DEWARP_SETTINGS;
+  }, [dewarpById]);
+
+  const isEnabled = useCallback((deviceId: string): boolean => {
+    return Boolean(dewarpById[deviceId]?.enabled);
+  }, [dewarpById]);
+
+  return {
+    dewarpById,
+    enableDewarp,
+    disableDewarp,
+    toggleDewarp,
+    updateSettings,
+    getSettings,
+    isEnabled
+  };
+}

--- a/src/types/video-dewarp.ts
+++ b/src/types/video-dewarp.ts
@@ -1,0 +1,22 @@
+export type LensModel = 'equidistant' | 'equisolid' | 'orthographic' | 'stereographic';
+
+export interface DewarpSettings {
+  lensModel: LensModel;
+  // Lens intrinsics in source pixel space
+  cx?: number;
+  cy?: number;
+  focalPx?: number;
+  // View parameters (degrees)
+  fovDeg: number;
+  yawDeg: number;
+  pitchDeg: number;
+  rollDeg: number;
+}
+
+export interface DewarpProps {
+  enabled: boolean;
+  settings: DewarpSettings;
+}
+
+
+


### PR DESCRIPTION
This pull request introduces a set of new components and supporting logic to enable advanced fisheye lens dewarping features in the video player. The main changes include interactive controls for dewarp mode, a dialog for advanced lens calibration, and a refactored player component to support these features.

**New Dewarp Functionality**

* Added `DewarpablePikoPlayer` component, which wraps the video player and overlays the dewarp canvas and controls when enabled. It manages video readiness, canvas sizing, and thumbnail display.
* Implemented `DewarpViewControls` for interactive pan, tilt, and zoom of the dewarped video. Users can drag to pan, use buttons or mouse wheel to zoom, and the controls are visually integrated with tooltips.

**Advanced Dewarp Settings and UI**

* Added `DewarpSettingsDialog` component for fine-tuning dewarp parameters, including field of view, orientation, lens model selection, and optical calibration (center and focal length). This dialog exposes all relevant settings for advanced users.
* Added `DewarpMenuSub` component for toggling dewarp mode and accessing advanced settings from a dropdown menu.

**Minor supporting changes**

* Minor formatting and whitespace adjustments in `play/page.tsx` to support new features. [[1]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R23) [[2]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R63) [[3]](diffhunk://#diff-03eaa3aeb4f15506f564c7516eab6de71278874b441e497b6250ce6c63690783R488)